### PR TITLE
Potential fix for code scanning alert no. 10: Bad HTML filtering regexp

### DIFF
--- a/custom_components/city_visitor_parking/frontend/dist/city-visitor-parking-card.js
+++ b/custom_components/city_visitor_parking/frontend/dist/city-visitor-parking-card.js
@@ -281,7 +281,7 @@ var u2 = Array.isArray;
 var d2 = (t4) => u2(t4) || "function" == typeof t4?.[Symbol.iterator];
 var f2 = "[ 	\n\f\r]";
 var v = /<(?:(!--|\/[^a-zA-Z])|(\/?[a-zA-Z][^>\s]*)|(\/?$))/g;
-var _ = /-->/g;
+var _ = /--!?>/g;
 var m = />/g;
 var p2 = RegExp(`>|${f2}(?:([^\\s"'>=/]+)(${f2}*=${f2}*(?:[^ 	
 \f\r"'\`<>=]|("|')|))|$)`, "g");


### PR DESCRIPTION
Potential fix for [https://github.com/sir-Unknown/ha_City-Visitor-Parking/security/code-scanning/10](https://github.com/sir-Unknown/ha_City-Visitor-Parking/security/code-scanning/10)

General fix: Adjust the comment-end regular expression so it matches both the standard `-->` and the permissive `--!>` that browsers will accept as a (erroneous but effective) comment terminator. This keeps the lightweight parser’s understanding of where comments end in sync with the browser’s behavior and closes the gap that CodeQL warns about.

Concrete change: In `custom_components/city_visitor_parking/frontend/dist/city-visitor-parking-card.js`, locate the declaration:

```js
var _ = /-->/g;
```

and replace it with a pattern that matches either `-->` or `--!>`. A simple, clear way is:

```js
var _ = /--!?>/g;
```

Explanation: `--!?>` matches `-->` (because `!` is optional due to `?`) and `--!>`; it does not introduce any change to other parts of the parsing logic and keeps the same flags (`g`). No additional imports or helper functions are needed; this is a self-contained change to the regex literal only.

No other lines in the shown snippet need modification, and no functionality outside the treatment of HTML comment endings is affected.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
