### PR TITLE
feat: streamline municipality setup and version logging

### DIFF
--- a/custom_components/city_visitor_parking/__init__.py
+++ b/custom_components/city_visitor_parking/__init__.py
@@ -33,6 +33,7 @@ from .client import async_create_client
 from .const import (
     CONF_API_URL,
     CONF_BASE_URL,
+    CONF_GUI_URL,
     CONF_MUNICIPALITY,
     CONF_OPERATING_TIME_OVERRIDES,
     CONF_PERMIT_ID,
@@ -46,6 +47,7 @@ from .helpers import normalize_override_windows
 from .models import AutoEndState, OperatingTimeOverrides, ProviderConfig
 from .runtime_data import CityVisitorParkingRuntimeData
 from .services import async_setup_services
+from .version import async_get_versions, format_log_metadata
 from .websocket_api import async_setup_websocket
 
 if TYPE_CHECKING:
@@ -101,6 +103,14 @@ CONFIG_SCHEMA: Final[Callable[[ConfigType], ConfigType]] = _config_entry_only_sc
 
 async def async_setup(hass: HomeAssistant, _config: ConfigType) -> bool:
     """Set up the City visitor parking integration."""
+    ha_cvp_version, pycvp_version = await async_get_versions(hass)
+    _LOGGER.debug(
+        "City Visitor Parking starting %s",
+        format_log_metadata(
+            ha_cvp_version=ha_cvp_version,
+            pycvp_version=pycvp_version,
+        ),
+    )
     await _async_register_frontend(hass, "http")
     async_when_setup(hass, "lovelace", _async_register_lovelace_resources)
     _LOGGER.debug("Setting up services and websocket API")
@@ -125,13 +135,17 @@ async def async_setup_entry(
         municipality_name=entry.data[CONF_MUNICIPALITY],
         base_url=entry.data.get(CONF_BASE_URL),
         api_url=entry.data.get(CONF_API_URL),
+        gui_url=entry.data.get(CONF_GUI_URL),
     )
+    ha_cvp_version, pycvp_version = await async_get_versions(hass)
     client = await async_create_client(hass, provider_config)
     provider = await client.get_provider(
         provider_config.provider_id,
         base_url=provider_config.base_url,
         api_uri=provider_config.api_url,
         request_context=provider_config.municipality_name,
+        ha_cvp_version=ha_cvp_version,
+        pycvp_version=pycvp_version,
     )
     _install_zone_validity_logging(provider)
     login_started = time.perf_counter()
@@ -308,8 +322,14 @@ async def _async_register_frontend(hass: HomeAssistant, _component: str) -> None
             )
         )
     else:
+        ha_cvp_version, pycvp_version = await async_get_versions(hass)
         _LOGGER.warning(
-            "Frontend translations directory is missing: %s", translations_path
+            "Frontend translations directory is missing: %s %s",
+            translations_path,
+            format_log_metadata(
+                ha_cvp_version=ha_cvp_version,
+                pycvp_version=pycvp_version,
+            ),
         )
 
     await http.async_register_static_paths(static_paths)

--- a/custom_components/city_visitor_parking/config_flow.py
+++ b/custom_components/city_visitor_parking/config_flow.py
@@ -6,7 +6,7 @@ import logging
 from collections.abc import Mapping
 from datetime import time
 from importlib import resources
-from typing import Final, Protocol, cast
+from typing import Final, cast
 
 import voluptuous as vol
 import yaml
@@ -18,7 +18,7 @@ from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers import selector
 from homeassistant.util import dt as dt_util
 from homeassistant.util import slugify
-from pycityvisitorparking import AuthError, Client, NetworkError
+from pycityvisitorparking import AuthError, NetworkError
 from pycityvisitorparking.exceptions import (
     PyCityVisitorParkingError,
     RateLimitError,
@@ -30,6 +30,7 @@ from .const import (
     CONF_API_URL,
     CONF_AUTO_END,
     CONF_BASE_URL,
+    CONF_GUI_URL,
     CONF_MUNICIPALITY,
     CONF_OPERATING_TIME_OVERRIDES,
     CONF_PERMIT_ID,
@@ -39,8 +40,8 @@ from .const import (
 )
 from .helpers import get_attr, normalize_override_windows
 from .models import ProviderConfig
+from .version import async_get_versions, format_log_metadata
 
-OTHER_OPTION: Final[str] = "other"
 SECTION_OPERATING_TIMES: Final[str] = "operating_times"
 
 _AUTH_SCHEMA: Final[vol.Schema] = vol.Schema(
@@ -49,19 +50,6 @@ _AUTH_SCHEMA: Final[vol.Schema] = vol.Schema(
         vol.Required(CONF_PASSWORD): cv.string,
     }
 )
-
-
-class _SelectorModule(Protocol):
-    """Protocol for selector module helpers."""
-
-    def selector(
-        self, config: Mapping[str, object]
-    ) -> selector.Selector[Mapping[str, object]]:
-        """Instantiate a selector."""
-        raise NotImplementedError
-
-
-SELECTOR = cast("_SelectorModule", selector).selector
 
 WEEKDAY_LABELS: Final[dict[str, str]] = {
     "mon": "monday",
@@ -95,80 +83,27 @@ class CityVisitorParkingConfigFlow(config_entries.ConfigFlow):
     ) -> config_entries.ConfigFlowResult:
         """Handle the initial step."""
         self._providers = await _async_load_providers(self.hass)
-        options = [
-            selector.SelectOptionDict(value=key, label=provider.municipality_name)
-            for key, provider in sorted(
-                self._providers.items(),
-                key=lambda item: item[1].municipality_name,
-            )
-        ]
-        options.append(selector.SelectOptionDict(value=OTHER_OPTION, label="Other"))
+        errors: dict[str, str] = {}
 
         if user_input is None:
-            schema = vol.Schema(
-                {
-                    vol.Required(CONF_MUNICIPALITY): SELECTOR(
-                        {"select": {"options": options}}
-                    )
-                }
-            )
-            return self.async_show_form(step_id="user", data_schema=schema)
+            return self._show_user_form(user_input, errors)
 
         selected = cast("str", user_input[CONF_MUNICIPALITY])
-        if selected == OTHER_OPTION:
-            return await self.async_step_other()
+        username = cast("str", user_input[CONF_USERNAME])
+        password = cast("str", user_input[CONF_PASSWORD])
+        self._credentials = {CONF_USERNAME: username, CONF_PASSWORD: password}
 
-        self._provider_config = self._providers[selected]
-        return await self.async_step_auth()
+        self._provider_config = self._resolve_provider_config(selected)
+        if self._provider_config is None:
+            errors["base"] = "invalid_municipality"
+            return self._show_user_form(user_input, errors)
+        permit_id = await self._async_validate_credentials(username, password, errors)
+        if errors:
+            return self._show_user_form(user_input, errors)
+        if permit_id is None:
+            return self.async_abort(reason="unknown")
 
-    async def async_step_other(
-        self, user_input: dict[str, object] | None = None
-    ) -> config_entries.ConfigFlowResult:
-        """Handle manual provider configuration."""
-        if user_input is None:
-            errors: dict[str, str] = {}
-            try:
-                providers = await _async_list_providers()
-            except NetworkError:
-                errors["base"] = "cannot_connect"
-                providers = []
-            # Allowed in config flow
-            except Exception as err:
-                _LOGGER.debug(
-                    "Unexpected error while listing providers: %s: %s",
-                    type(err).__name__,
-                    err,
-                )
-                errors["base"] = "unknown"
-                providers = []
-
-            provider_options = [
-                selector.SelectOptionDict(value=provider, label=provider)
-                for provider in providers
-            ]
-            schema = vol.Schema(
-                {
-                    vol.Required(CONF_PROVIDER_ID): SELECTOR(
-                        {"select": {"options": provider_options}}
-                    ),
-                    vol.Required(CONF_MUNICIPALITY): cv.string,
-                    vol.Optional(CONF_BASE_URL): cv.string,
-                    vol.Optional(CONF_API_URL): cv.string,
-                }
-            )
-            return self.async_show_form(
-                step_id="other",
-                data_schema=schema,
-                errors=errors,
-            )
-
-        self._provider_config = ProviderConfig(
-            provider_id=cast("str", user_input[CONF_PROVIDER_ID]),
-            municipality_name=cast("str", user_input[CONF_MUNICIPALITY]),
-            base_url=cast("str | None", user_input.get(CONF_BASE_URL)),
-            api_url=cast("str | None", user_input.get(CONF_API_URL)),
-        )
-        return await self.async_step_auth()
+        return await self._async_create_entry_for_permit(permit_id)
 
     async def async_step_auth(
         self, user_input: dict[str, object] | None = None
@@ -296,6 +231,59 @@ class CityVisitorParkingConfigFlow(config_entries.ConfigFlow):
 
         return await self._async_create_entry_for_permit(permit_id)
 
+    def _show_user_form(
+        self, user_input: Mapping[str, object] | None, errors: dict[str, str]
+    ) -> config_entries.ConfigFlowResult:
+        """Show the initial municipality and credential form."""
+        schema = vol.Schema(
+            {
+                vol.Required(CONF_MUNICIPALITY): selector.SelectSelector(
+                    selector.SelectSelectorConfig(
+                        options=[
+                            selector.SelectOptionDict(
+                                value=provider.municipality_name,
+                                label=provider.municipality_name,
+                            )
+                            for key, provider in sorted(
+                                self._providers.items(),
+                                key=lambda item: item[1].municipality_name,
+                            )
+                        ],
+                        custom_value=True,
+                        mode=selector.SelectSelectorMode.DROPDOWN,
+                        sort=True,
+                    )
+                ),
+                vol.Required(CONF_USERNAME): cv.string,
+                vol.Required(CONF_PASSWORD): cv.string,
+            }
+        )
+        suggested_values: dict[str, object] = {}
+        if user_input is not None:
+            suggested_values.update(user_input)
+            suggested_values.pop(CONF_PASSWORD, None)
+        return self.async_show_form(
+            step_id="user",
+            data_schema=self.add_suggested_values_to_schema(schema, suggested_values),
+            errors=errors,
+        )
+
+    def _resolve_provider_config(self, selection: str) -> ProviderConfig | None:
+        """Resolve a typed municipality selection to a known provider config."""
+        if provider_config := self._providers.get(selection):
+            return provider_config
+
+        normalized_selection = slugify(selection)
+        for key, provider in self._providers.items():
+            if provider.municipality_name.casefold() == selection.casefold():
+                return provider
+            if slugify(provider.municipality_name) == normalized_selection:
+                return provider
+            if slugify(key) == normalized_selection:
+                return provider
+
+        return None
+
     async def _async_create_entry_for_permit(
         self, permit_id: str
     ) -> config_entries.ConfigFlowResult:
@@ -314,6 +302,7 @@ class CityVisitorParkingConfigFlow(config_entries.ConfigFlow):
             CONF_MUNICIPALITY: self._provider_config.municipality_name,
             CONF_BASE_URL: self._provider_config.base_url,
             CONF_API_URL: self._provider_config.api_url,
+            CONF_GUI_URL: self._provider_config.gui_url,
             CONF_PERMIT_ID: permit_id,
             **self._credentials,
         }
@@ -330,6 +319,7 @@ class CityVisitorParkingConfigFlow(config_entries.ConfigFlow):
 
         error_key: str | None = None
         permit: object | None = None
+        ha_cvp_version, pycvp_version = await async_get_versions(self.hass)
         try:
             client = await async_create_client(self.hass, self._provider_config)
             provider = await client.get_provider(
@@ -337,44 +327,81 @@ class CityVisitorParkingConfigFlow(config_entries.ConfigFlow):
                 base_url=self._provider_config.base_url,
                 api_uri=self._provider_config.api_url,
                 request_context=self._provider_config.municipality_name,
+                ha_cvp_version=ha_cvp_version,
+                pycvp_version=pycvp_version,
             )
             await provider.login(username=username, password=password)
             permit = await provider.get_permit()
-        except AuthError:
+        except AuthError as err:
+            _LOGGER.debug(
+                "Auth error during login for %s: %s %s",
+                self._provider_config.provider_id,
+                err,
+                format_log_metadata(
+                    provider=self._provider_config.provider_id,
+                    city=self._provider_config.municipality_name,
+                    ha_cvp_version=ha_cvp_version,
+                    pycvp_version=pycvp_version,
+                ),
+            )
             error_key = "invalid_auth"
         except NetworkError:
             error_key = "cannot_connect"
         except RateLimitError as err:
             _LOGGER.debug(
-                "Rate limit during login for %s: %s: %s",
+                "Rate limit during login for %s: %s: %s %s",
                 self._provider_config.provider_id,
                 type(err).__name__,
                 err,
+                format_log_metadata(
+                    provider=self._provider_config.provider_id,
+                    city=self._provider_config.municipality_name,
+                    ha_cvp_version=ha_cvp_version,
+                    pycvp_version=pycvp_version,
+                ),
             )
             error_key = "rate_limit"
         except ServiceUnavailableError as err:
             _LOGGER.debug(
-                "Service unavailable during login for %s: %s: %s",
+                "Service unavailable during login for %s: %s: %s %s",
                 self._provider_config.provider_id,
                 type(err).__name__,
                 err,
+                format_log_metadata(
+                    provider=self._provider_config.provider_id,
+                    city=self._provider_config.municipality_name,
+                    ha_cvp_version=ha_cvp_version,
+                    pycvp_version=pycvp_version,
+                ),
             )
             error_key = "service_unavailable"
         except PyCityVisitorParkingError as err:
             _LOGGER.debug(
-                "Provider error during login for %s: %s: %s",
+                "Provider error during login for %s: %s: %s %s",
                 self._provider_config.provider_id,
                 type(err).__name__,
                 err,
+                format_log_metadata(
+                    provider=self._provider_config.provider_id,
+                    city=self._provider_config.municipality_name,
+                    ha_cvp_version=ha_cvp_version,
+                    pycvp_version=pycvp_version,
+                ),
             )
             error_key = "unknown"
         # Allowed in config flow
         except Exception as err:
             _LOGGER.debug(
-                "Unexpected error during login for %s: %s: %s",
+                "Unexpected error during login for %s: %s: %s %s",
                 self._provider_config.provider_id,
                 type(err).__name__,
                 err,
+                format_log_metadata(
+                    provider=self._provider_config.provider_id,
+                    city=self._provider_config.municipality_name,
+                    ha_cvp_version=ha_cvp_version,
+                    pycvp_version=pycvp_version,
+                ),
             )
             error_key = "unknown"
 
@@ -508,15 +535,9 @@ def _load_providers_sync() -> dict[str, ProviderConfig]:
             municipality_name=str(config["municipality_name"]),
             base_url=_normalize_optional_text(config.get("base_url")),
             api_url=_normalize_optional_text(config.get("api_url")),
+            gui_url=_normalize_optional_text(config.get("gui_url")),
         )
     return providers
-
-
-async def _async_list_providers() -> list[str]:
-    """Return provider IDs from the client library."""
-    client = Client()
-    providers = await client.list_providers()
-    return [provider.id for provider in providers]
 
 
 def _parse_time(value: object) -> time | None:
@@ -637,8 +658,8 @@ def _build_day_schema(
             raw_value = section_input.get(day_key, default_windows)
             if isinstance(raw_value, str):
                 default_windows = raw_value
-        day_schema[vol.Optional(day_key, default=default_windows)] = SELECTOR(
-            {"text": {}}
+        day_schema[vol.Optional(day_key, default=default_windows)] = (
+            selector.TextSelector(selector.TextSelectorConfig())
         )
     return day_schema
 

--- a/custom_components/city_visitor_parking/const.py
+++ b/custom_components/city_visitor_parking/const.py
@@ -15,6 +15,7 @@ CONF_PROVIDER_ID: Final = "provider_id"
 CONF_MUNICIPALITY: Final = "municipality_name"
 CONF_BASE_URL: Final = "base_url"
 CONF_API_URL: Final = "api_url"
+CONF_GUI_URL: Final = "gui_url"
 CONF_PERMIT_ID: Final = "permit_id"
 CONF_DESCRIPTION: Final = "description"
 

--- a/custom_components/city_visitor_parking/coordinator.py
+++ b/custom_components/city_visitor_parking/coordinator.py
@@ -25,6 +25,7 @@ from .models import (
 )
 from .models import Favorite as CoordinatorFavorite
 from .time_windows import windows_for_today
+from .version import async_get_versions, format_log_metadata
 
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Iterable, Mapping
@@ -96,6 +97,7 @@ class CityVisitorParkingCoordinator(DataUpdateCoordinator[CoordinatorData]):
 
     async def _async_update_data(self) -> CoordinatorData:
         """Fetch data from the API and normalize it."""
+        ha_cvp_version, pycvp_version = await async_get_versions(self.hass)
         try:
             _LOGGER.debug(
                 "Fetching permit, reservations, and favorites for %s (permit %s)",
@@ -132,25 +134,53 @@ class CityVisitorParkingCoordinator(DataUpdateCoordinator[CoordinatorData]):
                 self._unavailable_logged = False
         except AuthError as err:
             self._log_unavailable_once()
-            raise ConfigEntryAuthFailed from err
-        except (NetworkError, PyCityVisitorParkingError) as err:
-            self._log_unavailable_once()
             _LOGGER.debug(
-                "Coordinator fetch failed for %s (permit %s): %s: %s",
+                "Coordinator auth failed for %s (permit %s): %s: %s %s",
                 self._entry_title,
                 self._permit_id,
                 type(err).__name__,
                 err,
+                format_log_metadata(
+                    provider=self._provider.provider_id,
+                    city=getattr(self._provider, "_request_context_name", None)
+                    or "unknown",
+                    ha_cvp_version=ha_cvp_version,
+                    pycvp_version=pycvp_version,
+                ),
+            )
+            raise ConfigEntryAuthFailed from err
+        except (NetworkError, PyCityVisitorParkingError) as err:
+            self._log_unavailable_once()
+            _LOGGER.debug(
+                "Coordinator fetch failed for %s (permit %s): %s: %s %s",
+                self._entry_title,
+                self._permit_id,
+                type(err).__name__,
+                err,
+                format_log_metadata(
+                    provider=self._provider.provider_id,
+                    city=getattr(self._provider, "_request_context_name", None)
+                    or "unknown",
+                    ha_cvp_version=ha_cvp_version,
+                    pycvp_version=pycvp_version,
+                ),
             )
             raise UpdateFailed("API communication error") from err
         except Exception as err:  # Allowed in background tasks
             self._log_unavailable_once()
             _LOGGER.debug(
-                "Coordinator fetch failed unexpectedly for %s (permit %s): %s: %s",
+                "Coordinator fetch failed unexpectedly for %s (permit %s): %s: %s %s",
                 self._entry_title,
                 self._permit_id,
                 type(err).__name__,
                 err,
+                format_log_metadata(
+                    provider=self._provider.provider_id,
+                    city=getattr(self._provider, "_request_context_name", None)
+                    or "unknown",
+                    ha_cvp_version=ha_cvp_version,
+                    pycvp_version=pycvp_version,
+                ),
             )
             raise UpdateFailed("Unexpected error") from err
 

--- a/custom_components/city_visitor_parking/entity.py
+++ b/custom_components/city_visitor_parking/entity.py
@@ -44,12 +44,17 @@ class CityVisitorParkingEntity(
             else entry.title
         )
         self._attr_unique_id = f"{entry.unique_id}:{self._entity_key}"
+        configuration_url = None
+        runtime_data = getattr(entry, "runtime_data", None)
+        if runtime_data is not None:
+            configuration_url = runtime_data.provider_config.gui_url
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, entry.entry_id)},
             name=device_name,
             manufacturer="City visitor parking",
             model="Visitor parking permit",
             entry_type=DeviceEntryType.SERVICE,
+            configuration_url=configuration_url,
         )
         self._attr_extra_state_attributes: dict[str, object] = {
             ATTR_ATTRIBUTION: "Data provided by your municipality",

--- a/custom_components/city_visitor_parking/models.py
+++ b/custom_components/city_visitor_parking/models.py
@@ -17,6 +17,7 @@ class ProviderConfig:
     municipality_name: str
     base_url: str | None
     api_url: str | None
+    gui_url: str | None = None
 
 
 @dataclass(frozen=True)

--- a/custom_components/city_visitor_parking/providers.yaml
+++ b/custom_components/city_visitor_parking/providers.yaml
@@ -2,162 +2,189 @@ amstelveen:
   municipality_name: Amstelveen
   provider_id: 2park
   base_url: "https://mijn.2park.nl"
+  gui_url: "https://mijn.2park.nl/"
   api_url: "/gsmpark-app-www/json"
 
 apeldoorn:
   municipality_name: Apeldoorn
   provider_id: dvsportal
-  base_url: "https://parkeren.apeldoorn.nl"
+  base_url: "https://parkeren.apeldoorn.nl/"
+  gui_url: "https://parkeren.apeldoorn.nl/DVSPortal/"
   api_url: "/DVSPortal/api"
 
 assen:
   municipality_name: Assen
   provider_id: 2park
   base_url: "https://mijn.2park.nl"
+  gui_url: "https://mijn.2park.nl/"
   api_url: "/gsmpark-app-www/json"
 
 bergen_op_zoom:
   municipality_name: Bergen op Zoom
   provider_id: 2park
   base_url: "https://mijn.2park.nl"
+  gui_url: "https://mijn.2park.nl/"
   api_url: "/gsmpark-app-www/json"
 
 bloemendaal:
   municipality_name: Bloemendaal
   provider_id: dvsportal
   base_url: "https://parkeren.bloemendaal.nl"
+  gui_url: "https://parkeren.bloemendaal.nl/DVSPortal/"
   api_url: "/DVSWebAPI/api"
 
 breda:
   municipality_name: Breda
   provider_id: 2park
   base_url: "https://mijn.2park.nl"
+  gui_url: "https://mijn.2park.nl/"
   api_url: "/gsmpark-app-www/json"
 
 deventer:
   municipality_name: Deventer
   provider_id: 2park
   base_url: "https://mijn.2park.nl"
+  gui_url: "https://mijn.2park.nl/"
   api_url: "/gsmpark-app-www/json"
 
 delft:
   municipality_name: Delft
   provider_id: dvsportal
   base_url: "https://vergunningen.parkerendelft.com"
+  gui_url: "https://vergunningen.parkerendelft.com/DVSPortal/"
   api_url: "/DVSWebAPI/api"
 
 den_haag:
   municipality_name: Den Haag
   provider_id: the_hague
   base_url: "https://parkerendenhaag.denhaag.nl"
+  gui_url: "https://parkerendenhaag.denhaag.nl/"
   api_url: "api"
 
 s_hertogenbosch:
   municipality_name: "'s-Hertogenbosch"
   provider_id: dvsportal
   base_url: "https://parkeren.s-hertogenbosch.nl"
+  gui_url: "https://parkeren.s-hertogenbosch.nl/DVSPortal/"
   api_url: "/DVSPortal/api"
 
 doetinchem_buha:
   municipality_name: "Doetinchem (via Buha)"
   provider_id: dvsportal
   base_url: "https://parkeren.buha.nl"
+  gui_url: "https://parkeren.buha.nl/DVSPortal/"
   api_url: "/DVSWebAPI/api"
 
 dordrecht:
   municipality_name: Dordrecht
   provider_id: 2park
   base_url: "https://mijn.2park.nl"
+  gui_url: "https://mijn.2park.nl/"
   api_url: "/gsmpark-app-www/json"
 
 eindhoven:
   municipality_name: Eindhoven
   provider_id: 2park
   base_url: "https://mijn.2park.nl"
+  gui_url: "https://mijn.2park.nl/"
   api_url: "/gsmpark-app-www/json"
 
 emmen:
   municipality_name: Emmen
   provider_id: 2park
   base_url: "https://mijn.2park.nl"
+  gui_url: "https://mijn.2park.nl/"
   api_url: "/gsmpark-app-www/json"
 
 etten_leur:
   municipality_name: Etten-Leur
   provider_id: 2park
   base_url: "https://mijn.2park.nl"
+  gui_url: "https://mijn.2park.nl/"
   api_url: "/gsmpark-app-www/json"
 
 gorinchem:
   municipality_name: Gorinchem
   provider_id: 2park
   base_url: "https://mijn.2park.nl"
+  gui_url: "https://mijn.2park.nl/"
   api_url: "/gsmpark-app-www/json"
 
 groningen:
   municipality_name: Groningen
   provider_id: dvsportal
   base_url: "https://aanvraagparkeren.groningen.nl"
+  gui_url: "https://aanvraagparkeren.groningen.nl/DVSPortal/"
   api_url: "/DVSPortal/api"
 
 haarlem:
   municipality_name: Haarlem
   provider_id: dvsportal
   base_url: "https://parkeren.haarlem.nl"
+  gui_url: "https://parkeren.haarlem.nl/DVSPortal/"
   api_url: "/DVSWebAPI/api"
 
 harlingen:
   municipality_name: Harlingen
   provider_id: dvsportal
   base_url: "https://parkeervergunningen.harlingen.nl"
+  gui_url: "https://parkeervergunningen.harlingen.nl/DVSPortal/"
   api_url: "/DVSWebAPI/api"
 
 hardenberg:
   municipality_name: Hardenberg
   provider_id: 2park
   base_url: "https://mijn.2park.nl"
+  gui_url: "https://mijn.2park.nl/"
   api_url: "/gsmpark-app-www/json"
 
 harderwijk:
   municipality_name: Harderwijk
   provider_id: 2park
   base_url: "https://mijn.2park.nl"
+  gui_url: "https://mijn.2park.nl/"
   api_url: "/gsmpark-app-www/json"
 
 heemstede:
   municipality_name: Heemstede
   provider_id: dvsportal
   base_url: "https://parkeren.heemstede.nl"
+  gui_url: "https://parkeren.heemstede.nl/DVSPortal/"
   api_url: "/DVSWebAPI/api"
 
 heerenveen:
   municipality_name: Heerenveen
   provider_id: dvsportal
   base_url: "https://parkeren.heerenveen.nl"
+  gui_url: "https://parkeren.heerenveen.nl/DVSPortal/"
   api_url: "/DVSWebAPI/api"
 
 heerlen:
   municipality_name: Heerlen
   provider_id: dvsportal
   base_url: "https://parkeren.heerlen.nl"
+  gui_url: "https://parkeren.heerlen.nl/DVSPortal/"
   api_url: "/DVSPortal/api"
 
 hengelo:
   municipality_name: Hengelo
   provider_id: dvsportal
   base_url: "https://parkeren.hengelo.nl"
+  gui_url: "https://parkeren.hengelo.nl/DVSPortal/"
   api_url: "/DVSWebAPI/api"
 
 katwijk:
   municipality_name: Katwijk
   provider_id: dvsportal
   base_url: "https://parkeren.katwijk.nl"
+  gui_url: "https://parkeren.katwijk.nl/DVSPortal/"
   api_url: "/DVSWebAPI/api"
 
 leiden:
   municipality_name: Leiden
   provider_id: dvsportal
   base_url: "https://parkeren.leiden.nl"
+  gui_url: "https://parkeren.leiden.nl/DVSPortal/"
   api_url: "/DVSWebAPI/api"
 
 # The Leidschendam-Voorburg parking provider is currently not working, so it's commented out for now.
@@ -166,178 +193,210 @@ leiden:
 #   municipality_name: Leidschendam-Voorburg
 #   provider_id: dvsportal
 #   base_url: "https://parkeren.lv.nl"
+#   gui_url: "https://parkeren.lv.nl/DVSPortal/"
 #   api_url: "/DVSPortal/api"
 
 maastricht:
   municipality_name: Maastricht
   provider_id: 2park
   base_url: "https://mijn.2park.nl"
+  gui_url: "https://mijn.2park.nl/"
   api_url: "/gsmpark-app-www/json"
 
 middelburg:
   municipality_name: Middelburg
   provider_id: dvsportal
   base_url: "https://parkeren.middelburg.nl"
+  gui_url: "https://parkeren.middelburg.nl/DVSPortal/"
   api_url: "/DVSWebAPI/api"
 
 nijmegen:
   municipality_name: Nijmegen
   provider_id: dvsportal
   base_url: "https://parkeerproducten.nijmegen.nl"
+  gui_url: "https://parkeerproducten.nijmegen.nl/DVSPortal/"
   api_url: "/DVSPortal/api"
 
 nissewaard:
   municipality_name: Nissewaard
   provider_id: dvsportal
   base_url: "https://parkeren.nissewaard.nl"
+  gui_url: "https://parkeren.nissewaard.nl/DVSPortal/"
   api_url: "/DVSWebAPI/api"
 
 oldenzaal:
   municipality_name: Oldenzaal
   provider_id: dvsportal
   base_url: "https://parkeren.oldenzaal.nl"
+  gui_url: "https://parkeren.oldenzaal.nl/DVSPortal/"
   api_url: "/DVSWebAPI/api"
 
 oosterhout:
   municipality_name: Oosterhout
   provider_id: 2park
   base_url: "https://mijn.2park.nl"
+  gui_url: "https://mijn.2park.nl/"
   api_url: "/gsmpark-app-www/json"
 
 oss:
   municipality_name: Oss
   provider_id: 2park
   base_url: "https://mijn.2park.nl"
+  gui_url: "https://mijn.2park.nl/"
   api_url: "/gsmpark-app-www/json"
 
 rijswijk:
   municipality_name: Rijswijk
   provider_id: dvsportal
   base_url: "https://parkeren.rijswijk.nl"
+  gui_url: "https://parkeren.rijswijk.nl/DVSPortal/"
   api_url: "/DVSWebAPI/api"
 
 roermond:
   municipality_name: Roermond
   provider_id: dvsportal
   base_url: "https://parkeren.roermond.nl"
+  gui_url: "https://parkeren.roermond.nl/DVSPortal/"
   api_url: "/DVSWebAPI/api"
 
 roosendaal:
   municipality_name: Roosendaal
   provider_id: 2park
   base_url: "https://mijn.2park.nl"
+  gui_url: "https://mijn.2park.nl/"
   api_url: "/gsmpark-app-www/json"
 
-schouwen_duiveland:
-  municipality_name: Schouwen-Duiveland
-  provider_id: dvsportal
-  base_url: "https://parkeren.schouwen-duiveland.nl"
-  api_url: "/DVSWebAPI/api"
+# The Schouwen-Duiveland parking provider is currently not working, so it's commented out for now.
+# It is not working because only LoginMethod=Gebruiker is allowed. Please open an issue if you want this provider enabled.
+# schouwen_duiveland:
+#   municipality_name: Schouwen-Duiveland
+#   provider_id: dvsportal
+#   base_url: "https://parkeren.schouwen-duiveland.nl"
+#   gui_url: "https://parkeren.schouwen-duiveland.nl/DVSPortal/"
+#   api_url: "/DVSWebAPI/api"
 
 sittard_geleen:
   municipality_name: Sittard-Geleen
   provider_id: dvsportal
   base_url: "https://parkeren.sittard-geleen.nl"
+  gui_url: "https://parkeren.sittard-geleen.nl/DVSPortal/"
   api_url: "/DVSPortal/api"
 
 smallingerland:
   municipality_name: Smallingerland
   provider_id: dvsportal
   base_url: "https://parkeren.smallingerland.nl"
+  gui_url: "https://parkeren.smallingerland.nl/DVSPortal/"
   api_url: "/DVSPortal/api"
 
 sudwest_fryslan:
   municipality_name: Súdwest-Fryslân
   provider_id: dvsportal
   base_url: "https://parkeren.sudwestfryslan.nl"
+  gui_url: "https://parkeren.sudwestfryslan.nl/DVSPortal/"
   api_url: "/DVSWebAPI/api"
 
 sluis:
   municipality_name: Sluis
   provider_id: 2park
   base_url: "https://mijn.2park.nl"
+  gui_url: "https://mijn.2park.nl/"
   api_url: "/gsmpark-app-www/json"
 
 terneuzen:
   municipality_name: Terneuzen
   provider_id: 2park
   base_url: "https://mijn.2park.nl"
+  gui_url: "https://mijn.2park.nl/"
   api_url: "/gsmpark-app-www/json"
 
 tiel:
   municipality_name: Tiel
   provider_id: 2park
   base_url: "https://mijn.2park.nl"
+  gui_url: "https://mijn.2park.nl/"
   api_url: "/gsmpark-app-www/json"
 
 veere:
   municipality_name: Veere
   provider_id: dvsportal
   base_url: "https://parkeren.veere.nl"
+  gui_url: "https://parkeren.veere.nl/DVSPortal/"
   api_url: "/DVSWebAPI/api"
 
 veenendaal:
   municipality_name: Veenendaal
   provider_id: 2park
   base_url: "https://mijn.2park.nl"
+  gui_url: "https://mijn.2park.nl/"
   api_url: "/gsmpark-app-www/json"
 
 venlo:
   municipality_name: Venlo
   provider_id: dvsportal
   base_url: "https://parkeren.venlo.nl"
+  gui_url: "https://parkeren.venlo.nl/DVSPortal/"
   api_url: "/DVSWebAPI/api"
 
 vlaardingen:
   municipality_name: Vlaardingen
   provider_id: 2park
   base_url: "https://mijn.2park.nl"
+  gui_url: "https://mijn.2park.nl/"
   api_url: "/gsmpark-app-www/json"
 
 vlissingen:
   municipality_name: Vlissingen
   provider_id: dvsportal
   base_url: "https://parkeren.vlissingen.nl"
+  gui_url: "https://parkeren.vlissingen.nl/DVSPortal/"
   api_url: "/DVSPortal/api"
 
 waadhoeke:
   municipality_name: Waadhoeke
   provider_id: dvsportal
   base_url: "https://parkeren.waadhoeke.nl"
+  gui_url: "https://parkeren.waadhoeke.nl/DVSPortal/"
   api_url: "/DVSPortal/api"
 
 waalwijk:
   municipality_name: Waalwijk
   provider_id: dvsportal
   base_url: "https://parkeren.waalwijk.nl"
+  gui_url: "https://parkeren.waalwijk.nl/DVSPortal/"
   api_url: "/DVSWebAPI/api"
 
 weert:
   municipality_name: Weert
   provider_id: dvsportal
   base_url: "https://parkeerloket.weert.nl"
+  gui_url: "https://parkeerloket.weert.nl/DVSPortal/"
   api_url: "/DVSPortal/api"
 
 zaanstad:
   municipality_name: Zaanstad
   provider_id: dvsportal
   base_url: "https://parkeren.zaanstad.nl"
+  gui_url: "https://parkeren.zaanstad.nl/DVSPortal/"
   api_url: "/DVSPortal/api"
 
 zevenaar:
   municipality_name: Zevenaar
   provider_id: dvsportal
   base_url: "https://parkeren.zevenaar.nl"
+  gui_url: "https://parkeren.zevenaar.nl/DVSPortal/"
   api_url: "/DVSWebAPI/api"
 
 zutphen:
   municipality_name: Zutphen
   provider_id: dvsportal
   base_url: "https://parkeren.zutphen.nl"
+  gui_url: "https://parkeren.zutphen.nl/DVSPortal/"
   api_url: "/DVSWebAPI/api"
 
 zwolle:
   municipality_name: Zwolle
   provider_id: dvsportal
   base_url: "https://parkeerloket.zwolle.nl"
+  gui_url: "https://parkeerloket.zwolle.nl/DVSPortal/"
   api_url: "/DVSWebAPI/api"

--- a/custom_components/city_visitor_parking/services.py
+++ b/custom_components/city_visitor_parking/services.py
@@ -37,6 +37,7 @@ from .const import (
 )
 from .helpers import normalize_plate
 from .payloads import build_status_payload, normalize_favorites, reservation_payload
+from .version import async_get_versions, format_log_metadata
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
@@ -76,6 +77,14 @@ SELECTOR = cast("_SelectorModule", selector).selector
 DEVICE_SELECTOR: Final[selector.Selector[Mapping[str, object]]] = SELECTOR(
     {"device": {"integration": DOMAIN}}
 )
+
+
+def _runtime_log_context(runtime: CityVisitorParkingRuntimeData) -> dict[str, str]:
+    """Return logging context fields for a runtime-bound provider."""
+    return {
+        "provider": runtime.provider_config.provider_id,
+        "city": runtime.provider_config.municipality_name,
+    }
 
 
 def _error_detail(err: PyCityVisitorParkingError) -> str | None:
@@ -131,10 +140,27 @@ def _favorite_error_key(err: PyCityVisitorParkingError, detail_present: bool) ->
     return _error_key(err, "favorite", detail_present)
 
 
-def _raise_reservation_error(err: PyCityVisitorParkingError) -> NoReturn:
+def _raise_reservation_error(
+    err: PyCityVisitorParkingError,
+    *,
+    provider: str = "unknown",
+    city: str = "unknown",
+    ha_cvp_version: str = "unknown",
+    pycvp_version: str = "unknown",
+) -> NoReturn:
     """Raise a translated Home Assistant error for reservation failures."""
     detail = _error_detail(err)
-    _LOGGER.debug("Reservation request failed: %s: %s", type(err).__name__, err)
+    _LOGGER.debug(
+        "Reservation request failed: %s: %s %s",
+        type(err).__name__,
+        err,
+        format_log_metadata(
+            provider=provider,
+            city=city,
+            ha_cvp_version=ha_cvp_version,
+            pycvp_version=pycvp_version,
+        ),
+    )
     raise HomeAssistantError(
         translation_domain=DOMAIN,
         translation_key=_reservation_error_key(err, detail is not None),
@@ -142,16 +168,43 @@ def _raise_reservation_error(err: PyCityVisitorParkingError) -> NoReturn:
     ) from err
 
 
-def _raise_favorite_error(err: PyCityVisitorParkingError | TypeError) -> NoReturn:
+def _raise_favorite_error(
+    err: PyCityVisitorParkingError | TypeError,
+    *,
+    provider: str = "unknown",
+    city: str = "unknown",
+    ha_cvp_version: str = "unknown",
+    pycvp_version: str = "unknown",
+) -> NoReturn:
     """Raise a translated Home Assistant error for favorite failures."""
     if not isinstance(err, PyCityVisitorParkingError):
-        _LOGGER.debug("Favorite request failed: %s: %s", type(err).__name__, err)
+        _LOGGER.debug(
+            "Favorite request failed: %s: %s %s",
+            type(err).__name__,
+            err,
+            format_log_metadata(
+                provider=provider,
+                city=city,
+                ha_cvp_version=ha_cvp_version,
+                pycvp_version=pycvp_version,
+            ),
+        )
         raise HomeAssistantError(
             translation_domain=DOMAIN,
             translation_key="favorite_operation_failed",
         ) from err
     detail = _error_detail(err)
-    _LOGGER.debug("Favorite request failed: %s: %s", type(err).__name__, err)
+    _LOGGER.debug(
+        "Favorite request failed: %s: %s %s",
+        type(err).__name__,
+        err,
+        format_log_metadata(
+            provider=provider,
+            city=city,
+            ha_cvp_version=ha_cvp_version,
+            pycvp_version=pycvp_version,
+        ),
+    )
     raise HomeAssistantError(
         translation_domain=DOMAIN,
         translation_key=_favorite_error_key(err, detail is not None),
@@ -338,7 +391,13 @@ async def _async_handle_start_reservation(call: ServiceCall) -> None:
             end_time=end,
         )
     except PyCityVisitorParkingError as err:
-        _raise_reservation_error(err)
+        ha_cvp_version, pycvp_version = await async_get_versions(call.hass)
+        _raise_reservation_error(
+            err,
+            **_runtime_log_context(runtime),
+            ha_cvp_version=ha_cvp_version,
+            pycvp_version=pycvp_version,
+        )
     else:
         _LOGGER.debug(
             "Reservation start requested for device %s (start=%s end=%s)",
@@ -409,7 +468,13 @@ async def _async_handle_update_reservation(call: ServiceCall) -> None:
         )
     except (NotImplementedError, ProviderError) as err:
         if isinstance(err, ProviderError) and not _is_not_supported(err):
-            _raise_reservation_error(err)
+            ha_cvp_version, pycvp_version = await async_get_versions(call.hass)
+            _raise_reservation_error(
+                err,
+                **_runtime_log_context(runtime),
+                ha_cvp_version=ha_cvp_version,
+                pycvp_version=pycvp_version,
+            )
         await _fallback_update_reservation(
             runtime,
             reservation_id,
@@ -418,7 +483,13 @@ async def _async_handle_update_reservation(call: ServiceCall) -> None:
             license_plate,
         )
     except PyCityVisitorParkingError as err:
-        _raise_reservation_error(err)
+        ha_cvp_version, pycvp_version = await async_get_versions(call.hass)
+        _raise_reservation_error(
+            err,
+            **_runtime_log_context(runtime),
+            ha_cvp_version=ha_cvp_version,
+            pycvp_version=pycvp_version,
+        )
     else:
         _LOGGER.debug(
             "Reservation update requested for device %s reservation %s "
@@ -441,7 +512,13 @@ async def _async_handle_end_reservation(call: ServiceCall) -> None:
             dt_util.utcnow(),
         )
     except PyCityVisitorParkingError as err:
-        _raise_reservation_error(err)
+        ha_cvp_version, pycvp_version = await async_get_versions(call.hass)
+        _raise_reservation_error(
+            err,
+            **_runtime_log_context(runtime),
+            ha_cvp_version=ha_cvp_version,
+            pycvp_version=pycvp_version,
+        )
     else:
         _LOGGER.debug(
             "Reservation end requested for device %s reservation %s",
@@ -468,7 +545,13 @@ async def _async_handle_add_favorite(call: ServiceCall) -> None:
             type(err).__name__,
             err,
         )
-        _raise_favorite_error(err)
+        ha_cvp_version, pycvp_version = await async_get_versions(call.hass)
+        _raise_favorite_error(
+            err,
+            **_runtime_log_context(runtime),
+            ha_cvp_version=ha_cvp_version,
+            pycvp_version=pycvp_version,
+        )
 
 
 async def _async_handle_update_favorite(call: ServiceCall) -> None:
@@ -494,7 +577,13 @@ async def _async_handle_update_favorite(call: ServiceCall) -> None:
         await runtime.provider.update_favorite(**update_data)
     except (NotImplementedError, ProviderError) as err:
         if isinstance(err, ProviderError) and not _is_not_supported(err):
-            _raise_favorite_error(err)
+            ha_cvp_version, pycvp_version = await async_get_versions(call.hass)
+            _raise_favorite_error(
+                err,
+                **_runtime_log_context(runtime),
+                ha_cvp_version=ha_cvp_version,
+                pycvp_version=pycvp_version,
+            )
         await _fallback_update_favorite(runtime, favorite_id, license_plate, name)
     except (TypeError, PyCityVisitorParkingError) as err:
         _LOGGER.debug(
@@ -504,7 +593,13 @@ async def _async_handle_update_favorite(call: ServiceCall) -> None:
             type(err).__name__,
             err,
         )
-        _raise_favorite_error(err)
+        ha_cvp_version, pycvp_version = await async_get_versions(call.hass)
+        _raise_favorite_error(
+            err,
+            **_runtime_log_context(runtime),
+            ha_cvp_version=ha_cvp_version,
+            pycvp_version=pycvp_version,
+        )
 
 
 async def _async_handle_remove_favorite(call: ServiceCall) -> None:
@@ -516,7 +611,13 @@ async def _async_handle_remove_favorite(call: ServiceCall) -> None:
         await runtime.provider.remove_favorite(favorite_id)
         _LOGGER.debug("Removed favorite for device %s", call.data[ATTR_DEVICE_ID])
     except PyCityVisitorParkingError as err:
-        _raise_favorite_error(err)
+        ha_cvp_version, pycvp_version = await async_get_versions(call.hass)
+        _raise_favorite_error(
+            err,
+            **_runtime_log_context(runtime),
+            ha_cvp_version=ha_cvp_version,
+            pycvp_version=pycvp_version,
+        )
 
 
 async def _async_handle_list_reservations(
@@ -588,7 +689,13 @@ async def _async_handle_list_favorites(call: ServiceCall) -> dict[str, JsonValue
     try:
         favorites = await runtime.provider.list_favorites()
     except PyCityVisitorParkingError as err:
-        _raise_favorite_error(err)
+        ha_cvp_version, pycvp_version = await async_get_versions(call.hass)
+        _raise_favorite_error(
+            err,
+            **_runtime_log_context(runtime),
+            ha_cvp_version=ha_cvp_version,
+            pycvp_version=pycvp_version,
+        )
 
     normalized: list[JsonValueType] = []
     for favorite in normalize_favorites(favorites):
@@ -686,7 +793,15 @@ async def _fallback_update_reservation(
             type(err).__name__,
             err,
         )
-        _raise_reservation_error(err)
+        ha_cvp_version, pycvp_version = await async_get_versions(
+            runtime.coordinator.hass
+        )
+        _raise_reservation_error(
+            err,
+            **_runtime_log_context(runtime),
+            ha_cvp_version=ha_cvp_version,
+            pycvp_version=pycvp_version,
+        )
     else:
         _LOGGER.debug("Fallback reservation update succeeded for %s", reservation_id)
 
@@ -729,7 +844,15 @@ async def _fallback_update_favorite(
             type(err).__name__,
             err,
         )
-        _raise_favorite_error(err)
+        ha_cvp_version, pycvp_version = await async_get_versions(
+            runtime.coordinator.hass
+        )
+        _raise_favorite_error(
+            err,
+            **_runtime_log_context(runtime),
+            ha_cvp_version=ha_cvp_version,
+            pycvp_version=pycvp_version,
+        )
     else:
         _LOGGER.debug("Fallback favorite update succeeded for %s", favorite_id)
 

--- a/custom_components/city_visitor_parking/translations/en.json
+++ b/custom_components/city_visitor_parking/translations/en.json
@@ -3,19 +3,11 @@
     "step": {
       "user": {
         "title": "Set up visitor parking",
-        "description": "Choose your municipality.",
+        "description": "Choose your municipality and sign in to your visitor parking account.",
         "data": {
-          "municipality_name": "Municipality"
-        }
-      },
-      "other": {
-        "title": "Other municipality",
-        "description": "Enter the provider details for your municipality.",
-        "data": {
-          "provider_id": "Provider ID",
-          "municipality_name": "Municipality name",
-          "base_url": "Base URL",
-          "api_url": "API URL"
+          "municipality_name": "Municipality",
+          "username": "Username",
+          "password": "Password"
         }
       },
       "auth": {
@@ -57,6 +49,7 @@
     },
     "error": {
       "cannot_connect": "Unable to connect. Check your network connection and try again.",
+      "invalid_municipality": "Unknown municipality. Choose a municipality from the list or enter a matching name.",
       "invalid_auth": "Invalid credentials.",
       "no_permits": "No permits were found for this account.",
       "rate_limit": "Too many requests to the provider. Please wait a moment and try again.",

--- a/custom_components/city_visitor_parking/translations/nl.json
+++ b/custom_components/city_visitor_parking/translations/nl.json
@@ -3,19 +3,11 @@
     "step": {
       "user": {
         "title": "Bezoekersparkeren instellen",
-        "description": "Kies je gemeente.",
+        "description": "Kies je gemeente en meld je aan bij je bezoekersparkeren-account.",
         "data": {
-          "municipality_name": "Gemeente"
-        }
-      },
-      "other": {
-        "title": "Andere gemeente",
-        "description": "Voer de providergegevens van je gemeente in.",
-        "data": {
-          "provider_id": "Provider-ID",
-          "municipality_name": "Gemeentenaam",
-          "base_url": "Basis-URL",
-          "api_url": "API-URL"
+          "municipality_name": "Gemeente",
+          "username": "Gebruikersnaam",
+          "password": "Wachtwoord"
         }
       },
       "auth": {
@@ -57,6 +49,7 @@
     },
     "error": {
       "cannot_connect": "Kan geen verbinding maken. Controleer je netwerk en probeer het opnieuw.",
+      "invalid_municipality": "Onbekende gemeente. Kies een gemeente uit de lijst of voer een overeenkomende naam in.",
       "invalid_auth": "Ongeldige inloggegevens.",
       "no_permits": "Geen vergunningen gevonden voor dit account.",
       "rate_limit": "Te veel verzoeken naar de provider. Wacht even en probeer het later opnieuw.",

--- a/custom_components/city_visitor_parking/version.py
+++ b/custom_components/city_visitor_parking/version.py
@@ -1,0 +1,53 @@
+"""Shared version helpers for City visitor parking logging."""
+
+from __future__ import annotations
+
+import importlib.metadata
+from typing import TYPE_CHECKING
+
+from homeassistant.loader import async_get_integration
+
+from .const import DOMAIN
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
+
+_VERSION_CACHE_KEY = f"{DOMAIN}_versions"
+
+
+async def async_get_versions(hass: HomeAssistant) -> tuple[str, str]:
+    """Return cached integration and library versions."""
+    if cached_versions := hass.data.get(_VERSION_CACHE_KEY):
+        return cached_versions
+
+    integration = await async_get_integration(hass, DOMAIN)
+    ha_cvp_version = str(integration.manifest.get("version", "unknown"))
+    try:
+        pycvp_version = await hass.async_add_executor_job(
+            importlib.metadata.version, "pycityvisitorparking"
+        )
+    except importlib.metadata.PackageNotFoundError:
+        pycvp_version = "unknown"
+
+    versions = (ha_cvp_version, pycvp_version)
+    hass.data[_VERSION_CACHE_KEY] = versions
+    return versions
+
+
+def get_cached_versions(hass: HomeAssistant) -> tuple[str, str]:
+    """Return cached versions, or unknown values when not initialized yet."""
+    return hass.data.get(_VERSION_CACHE_KEY, ("unknown", "unknown"))
+
+
+def format_log_metadata(
+    *,
+    provider: str = "unknown",
+    city: str = "unknown",
+    ha_cvp_version: str = "unknown",
+    pycvp_version: str = "unknown",
+) -> str:
+    """Return a consistent logging metadata suffix."""
+    return (
+        f"(provider={provider}, city={city}, "
+        f"hacvp={ha_cvp_version}, pycvp={pycvp_version})"
+    )

--- a/tests/components/city_visitor_parking/test_config_flow.py
+++ b/tests/components/city_visitor_parking/test_config_flow.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from datetime import time
 from types import SimpleNamespace
 from typing import TYPE_CHECKING, Protocol
@@ -9,10 +10,10 @@ from unittest.mock import AsyncMock
 
 import voluptuous as vol
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+from homeassistant.helpers import selector
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.city_visitor_parking.config_flow import (
-    OTHER_OPTION,
     CityVisitorParkingConfigFlow,
     _day_windows_key,
     _format_override_windows,
@@ -24,6 +25,7 @@ from custom_components.city_visitor_parking.config_flow import (
 from custom_components.city_visitor_parking.const import (
     CONF_API_URL,
     CONF_BASE_URL,
+    CONF_GUI_URL,
     CONF_MUNICIPALITY,
     CONF_PERMIT_ID,
     CONF_PROVIDER_ID,
@@ -39,126 +41,41 @@ if TYPE_CHECKING:
     from types import ModuleType
 
     from homeassistant.core import HomeAssistant
-    from pytest import MonkeyPatch
+    from pytest import LogCaptureFixture, MonkeyPatch
 
-KNOWN_MUNICIPALITY = "apeldoorn"
+KNOWN_MUNICIPALITY = "Apeldoorn"
 
 
-async def test_municipality_dropdown_includes_other(hass: HomeAssistant) -> None:
-    """Ensure the municipality list includes "Other"."""
+async def test_municipality_selector_uses_sorted_dropdown(
+    hass: HomeAssistant,
+) -> None:
+    """Ensure the municipality field uses a sorted HA select dropdown."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": "user"}
     )
     assert result["type"] == "form"
 
     schema = result["data_schema"].schema
-    selector = schema[vol.Required(CONF_MUNICIPALITY)]
-    values = _extract_option_values(selector)
+    municipality_selector = schema[vol.Required(CONF_MUNICIPALITY)]
+    values = _extract_option_values(municipality_selector)
+    config = _extract_selector_config(municipality_selector)
+    labels = _extract_option_labels(municipality_selector)
 
+    assert isinstance(municipality_selector, selector.SelectSelector)
     assert KNOWN_MUNICIPALITY in values
-    assert OTHER_OPTION in values
+    assert CONF_USERNAME in {key.schema for key in schema}
+    assert CONF_PASSWORD in {key.schema for key in schema}
+    assert "other" not in values
+    assert config["custom_value"] is True
+    assert config["mode"] == selector.SelectSelectorMode.DROPDOWN
+    assert config["sort"] is True
+    assert labels == sorted(labels)
 
 
-async def test_known_municipality_skips_manual_step(hass: HomeAssistant) -> None:
-    """Known municipalities should jump to auth."""
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": "user"}
-    )
-    result = await hass.config_entries.flow.async_configure(
-        result["flow_id"], {CONF_MUNICIPALITY: KNOWN_MUNICIPALITY}
-    )
-
-    assert result["type"] == "form"
-    assert result["step_id"] == "auth"
-
-
-async def test_other_municipality_requires_manual_fields(hass: HomeAssistant) -> None:
-    """Other municipality must show manual provider fields."""
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": "user"}
-    )
-    result = await hass.config_entries.flow.async_configure(
-        result["flow_id"], {CONF_MUNICIPALITY: OTHER_OPTION}
-    )
-
-    schema = result["data_schema"].schema
-    assert CONF_PROVIDER_ID in {key.schema for key in schema}
-    assert CONF_MUNICIPALITY in {key.schema for key in schema}
-
-
-async def test_other_municipality_list_providers_network_error(
-    hass: HomeAssistant, monkeypatch: MonkeyPatch, pv_library: ModuleType
-) -> None:
-    """Provider list errors should surface in the form."""
-    monkeypatch.setattr(
-        "custom_components.city_visitor_parking.config_flow._async_list_providers",
-        AsyncMock(side_effect=pv_library.NetworkError),
-    )
-
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": "user"}
-    )
-    result = await hass.config_entries.flow.async_configure(
-        result["flow_id"], {CONF_MUNICIPALITY: OTHER_OPTION}
-    )
-
-    assert result["type"] == "form"
-    assert result["errors"]["base"] == "cannot_connect"
-
-
-async def test_other_municipality_list_providers_unknown_error(
+async def test_config_flow_accepts_custom_municipality_label(
     hass: HomeAssistant, monkeypatch: MonkeyPatch
 ) -> None:
-    """Unexpected provider list errors should map to unknown."""
-    monkeypatch.setattr(
-        "custom_components.city_visitor_parking.config_flow._async_list_providers",
-        AsyncMock(side_effect=RuntimeError),
-    )
-
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": "user"}
-    )
-    result = await hass.config_entries.flow.async_configure(
-        result["flow_id"], {CONF_MUNICIPALITY: OTHER_OPTION}
-    )
-
-    assert result["type"] == "form"
-    assert result["errors"]["base"] == "unknown"
-
-
-async def test_other_municipality_manual_provider_flow(
-    hass: HomeAssistant, monkeypatch: MonkeyPatch
-) -> None:
-    """Manual provider step should proceed to auth."""
-    monkeypatch.setattr(
-        "custom_components.city_visitor_parking.config_flow._async_list_providers",
-        AsyncMock(return_value=["manual"]),
-    )
-
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": "user"}
-    )
-    result = await hass.config_entries.flow.async_configure(
-        result["flow_id"], {CONF_MUNICIPALITY: OTHER_OPTION}
-    )
-    result = await hass.config_entries.flow.async_configure(
-        result["flow_id"],
-        {
-            CONF_PROVIDER_ID: "manual",
-            CONF_MUNICIPALITY: "Custom",
-            "base_url": "https://example.com",
-            "api_url": "https://example.com/api",
-        },
-    )
-
-    assert result["type"] == "form"
-    assert result["step_id"] == "auth"
-
-
-async def test_config_flow_success(
-    hass: HomeAssistant, monkeypatch: MonkeyPatch
-) -> None:
-    """Successful flow creates the entry with a permit title."""
+    """A typed municipality label should resolve to the matching provider."""
     provider = AsyncMock()
     provider.get_permit.return_value = {"id": "PERMIT1", "name": "Permit One"}
     client = AsyncMock()
@@ -172,23 +89,24 @@ async def test_config_flow_success(
         DOMAIN, context={"source": "user"}
     )
     result = await hass.config_entries.flow.async_configure(
-        result["flow_id"], {CONF_MUNICIPALITY: KNOWN_MUNICIPALITY}
-    )
-    result = await hass.config_entries.flow.async_configure(
-        result["flow_id"], {CONF_USERNAME: "user", CONF_PASSWORD: "pass"}
+        result["flow_id"],
+        {
+            CONF_MUNICIPALITY: "Apeldoorn",
+            CONF_USERNAME: "user",
+            CONF_PASSWORD: "pass",
+        },
     )
 
     assert result["type"] == "create_entry"
     assert result["title"] == "Apeldoorn - PERMIT1"
-    assert result["data"][CONF_PERMIT_ID] == "PERMIT1"
 
 
-async def test_config_flow_invalid_auth(
-    hass: HomeAssistant, monkeypatch: MonkeyPatch, pv_library: ModuleType
+async def test_config_flow_accepts_slugified_municipality_input(
+    hass: HomeAssistant, monkeypatch: MonkeyPatch
 ) -> None:
-    """Invalid credentials should be reported."""
+    """A slugified municipality value should still resolve for compatibility."""
     provider = AsyncMock()
-    provider.login.side_effect = pv_library.AuthError
+    provider.get_permit.return_value = {"id": "PERMIT1", "name": "Permit One"}
     client = AsyncMock()
     client.get_provider.return_value = provider
     monkeypatch.setattr(
@@ -200,14 +118,107 @@ async def test_config_flow_invalid_auth(
         DOMAIN, context={"source": "user"}
     )
     result = await hass.config_entries.flow.async_configure(
-        result["flow_id"], {CONF_MUNICIPALITY: KNOWN_MUNICIPALITY}
+        result["flow_id"],
+        {
+            CONF_MUNICIPALITY: "apeldoorn",
+            CONF_USERNAME: "user",
+            CONF_PASSWORD: "pass",
+        },
+    )
+
+    assert result["type"] == "create_entry"
+    assert result["title"] == "Apeldoorn - PERMIT1"
+
+
+async def test_config_flow_rejects_unknown_custom_municipality(
+    hass: HomeAssistant,
+) -> None:
+    """An unknown typed municipality should return a validation error."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": "user"}
     )
     result = await hass.config_entries.flow.async_configure(
-        result["flow_id"], {CONF_USERNAME: "user", CONF_PASSWORD: "pass"}
+        result["flow_id"],
+        {
+            CONF_MUNICIPALITY: "Not A Real Municipality",
+            CONF_USERNAME: "user",
+            CONF_PASSWORD: "pass",
+        },
     )
 
     assert result["type"] == "form"
+    assert result["errors"]["base"] == "invalid_municipality"
+
+
+async def test_config_flow_success(
+    hass: HomeAssistant, monkeypatch: MonkeyPatch
+) -> None:
+    """Successful flow creates the entry from the initial step."""
+    provider = AsyncMock()
+    provider.get_permit.return_value = {"id": "PERMIT1", "name": "Permit One"}
+    client = AsyncMock()
+    client.get_provider.return_value = provider
+    monkeypatch.setattr(
+        "custom_components.city_visitor_parking.config_flow.async_create_client",
+        AsyncMock(return_value=client),
+    )
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": "user"}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            CONF_MUNICIPALITY: KNOWN_MUNICIPALITY,
+            CONF_USERNAME: "user",
+            CONF_PASSWORD: "pass",
+        },
+    )
+
+    assert result["type"] == "create_entry"
+    assert result["title"] == "Apeldoorn - PERMIT1"
+    assert result["data"][CONF_PERMIT_ID] == "PERMIT1"
+    assert result["data"][CONF_GUI_URL] == "https://parkeren.apeldoorn.nl/DVSPortal/"
+
+
+async def test_config_flow_invalid_auth(
+    hass: HomeAssistant,
+    monkeypatch: MonkeyPatch,
+    pv_library: ModuleType,
+    caplog: LogCaptureFixture,
+) -> None:
+    """Invalid credentials should be reported."""
+    provider = AsyncMock()
+    provider.login.side_effect = pv_library.AuthError
+    client = AsyncMock()
+    client.get_provider.return_value = provider
+    monkeypatch.setattr(
+        "custom_components.city_visitor_parking.config_flow.async_create_client",
+        AsyncMock(return_value=client),
+    )
+    monkeypatch.setattr(
+        "custom_components.city_visitor_parking.config_flow.async_get_versions",
+        AsyncMock(return_value=("1.2.3", "4.5.6")),
+    )
+
+    with caplog.at_level(
+        logging.DEBUG, logger="custom_components.city_visitor_parking.config_flow"
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": "user"}
+        )
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_MUNICIPALITY: KNOWN_MUNICIPALITY,
+                CONF_USERNAME: "user",
+                CONF_PASSWORD: "pass",
+            },
+        )
+
+    assert result["type"] == "form"
     assert result["errors"]["base"] == "invalid_auth"
+    assert "hacvp=1.2.3 pycvp=4.5.6" in caplog.text
 
 
 async def test_config_flow_cannot_connect(
@@ -227,10 +238,12 @@ async def test_config_flow_cannot_connect(
         DOMAIN, context={"source": "user"}
     )
     result = await hass.config_entries.flow.async_configure(
-        result["flow_id"], {CONF_MUNICIPALITY: KNOWN_MUNICIPALITY}
-    )
-    result = await hass.config_entries.flow.async_configure(
-        result["flow_id"], {CONF_USERNAME: "user", CONF_PASSWORD: "pass"}
+        result["flow_id"],
+        {
+            CONF_MUNICIPALITY: KNOWN_MUNICIPALITY,
+            CONF_USERNAME: "user",
+            CONF_PASSWORD: "pass",
+        },
     )
 
     assert result["type"] == "form"
@@ -254,10 +267,12 @@ async def test_config_flow_unknown_error(
         DOMAIN, context={"source": "user"}
     )
     result = await hass.config_entries.flow.async_configure(
-        result["flow_id"], {CONF_MUNICIPALITY: KNOWN_MUNICIPALITY}
-    )
-    result = await hass.config_entries.flow.async_configure(
-        result["flow_id"], {CONF_USERNAME: "user", CONF_PASSWORD: "pass"}
+        result["flow_id"],
+        {
+            CONF_MUNICIPALITY: KNOWN_MUNICIPALITY,
+            CONF_USERNAME: "user",
+            CONF_PASSWORD: "pass",
+        },
     )
 
     assert result["type"] == "form"
@@ -421,7 +436,7 @@ async def test_validate_credentials_requires_provider(hass: HomeAssistant) -> No
 
 
 async def test_validate_credentials_unexpected_error(
-    hass: HomeAssistant, monkeypatch: MonkeyPatch
+    hass: HomeAssistant, monkeypatch: MonkeyPatch, caplog: LogCaptureFixture
 ) -> None:
     """Unexpected errors during validation should map to unknown."""
     flow = CityVisitorParkingConfigFlow()
@@ -437,12 +452,20 @@ async def test_validate_credentials_unexpected_error(
         "custom_components.city_visitor_parking.config_flow.async_create_client",
         AsyncMock(side_effect=RuntimeError),
     )
+    monkeypatch.setattr(
+        "custom_components.city_visitor_parking.config_flow.async_get_versions",
+        AsyncMock(return_value=("1.2.3", "4.5.6")),
+    )
 
     errors: dict[str, str] = {}
-    permit_id = await flow._async_validate_credentials("user", "pass", errors)
+    with caplog.at_level(
+        logging.DEBUG, logger="custom_components.city_visitor_parking.config_flow"
+    ):
+        permit_id = await flow._async_validate_credentials("user", "pass", errors)
 
     assert permit_id is None
     assert errors["base"] == "unknown"
+    assert "hacvp=1.2.3 pycvp=4.5.6" in caplog.text
 
 
 async def test_validate_credentials_no_permits(
@@ -511,8 +534,47 @@ class _SelectorConfig(Protocol):
     config: dict[str, object]
 
 
+def _extract_selector_config(selector: _SelectorConfig) -> dict[str, object]:
+    """Return the config dict from a selector field."""
+    return selector.config
+
+
 def _extract_option_values(selector: dict[str, object] | _SelectorConfig) -> list[str]:
     """Return option values from a selector field."""
+    option_dicts = _extract_selector_options(selector)
+
+    values: list[str] = []
+    for option in option_dicts:
+        if isinstance(option, str):
+            values.append(option)
+            continue
+        if isinstance(option, dict):
+            values.append(option["value"])
+        else:
+            values.append(option.value)
+    return values
+
+
+def _extract_option_labels(selector: dict[str, object] | _SelectorConfig) -> list[str]:
+    """Return option labels from a selector field."""
+    option_dicts = _extract_selector_options(selector)
+
+    labels: list[str] = []
+    for option in option_dicts:
+        if isinstance(option, str):
+            labels.append(option)
+            continue
+        if isinstance(option, dict):
+            labels.append(option["label"])
+        else:
+            labels.append(option.label)
+    return labels
+
+
+def _extract_selector_options(
+    selector: dict[str, object] | _SelectorConfig,
+) -> list[object]:
+    """Return the option entries from a selector field."""
     if isinstance(selector, dict):
         selector_dict = selector
         nested = selector_dict.get("selector")
@@ -528,17 +590,7 @@ def _extract_option_values(selector: dict[str, object] | _SelectorConfig) -> lis
             options = selector_dict.get("options", [])
     else:
         options = selector.config["options"]
-
-    values: list[str] = []
-    for option in options:
-        if isinstance(option, str):
-            values.append(option)
-            continue
-        if isinstance(option, dict):
-            values.append(option["value"])
-        else:
-            values.append(option.value)
-    return values
+    return list(options)
 
 
 def _create_entry() -> MockConfigEntry:

--- a/tests/components/city_visitor_parking/test_config_flow.py
+++ b/tests/components/city_visitor_parking/test_config_flow.py
@@ -218,7 +218,7 @@ async def test_config_flow_invalid_auth(
 
     assert result["type"] == "form"
     assert result["errors"]["base"] == "invalid_auth"
-    assert "hacvp=1.2.3 pycvp=4.5.6" in caplog.text
+    assert "hacvp=1.2.3, pycvp=4.5.6" in caplog.text
 
 
 async def test_config_flow_cannot_connect(
@@ -465,7 +465,7 @@ async def test_validate_credentials_unexpected_error(
 
     assert permit_id is None
     assert errors["base"] == "unknown"
-    assert "hacvp=1.2.3 pycvp=4.5.6" in caplog.text
+    assert "hacvp=1.2.3, pycvp=4.5.6" in caplog.text
 
 
 async def test_validate_credentials_no_permits(

--- a/tests/components/city_visitor_parking/test_coordinator.py
+++ b/tests/components/city_visitor_parking/test_coordinator.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from datetime import UTC, datetime, time, timedelta
 from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any, cast
@@ -54,6 +55,7 @@ if TYPE_CHECKING:
     from types import ModuleType
 
     from homeassistant.core import HomeAssistant
+    from pytest import LogCaptureFixture, MonkeyPatch
 
 EXPECTED_MINUTES = 15
 
@@ -91,7 +93,10 @@ async def test_auto_end_reservation_once(hass: HomeAssistant) -> None:
 
 
 async def test_auth_failure_triggers_reauth(
-    hass: HomeAssistant, pv_library: ModuleType
+    hass: HomeAssistant,
+    pv_library: ModuleType,
+    monkeypatch: MonkeyPatch,
+    caplog: LogCaptureFixture,
 ) -> None:
     """Auth errors should raise ConfigEntryAuthFailed."""
     entry = _create_entry(auto_end=False)
@@ -99,6 +104,10 @@ async def test_auth_failure_triggers_reauth(
 
     provider = AsyncMock()
     provider.get_permit.side_effect = pv_library.AuthError
+    monkeypatch.setattr(
+        "custom_components.city_visitor_parking.coordinator.async_get_versions",
+        AsyncMock(return_value=("1.2.3", "4.5.6")),
+    )
 
     coordinator = CityVisitorParkingCoordinator(
         hass,
@@ -108,12 +117,19 @@ async def test_auth_failure_triggers_reauth(
         auto_end_state=AutoEndState(),
     )
 
-    await coordinator.async_refresh()
+    with caplog.at_level(
+        logging.DEBUG, logger="custom_components.city_visitor_parking.coordinator"
+    ):
+        await coordinator.async_refresh()
     assert isinstance(coordinator.last_exception, ConfigEntryAuthFailed)
+    assert "hacvp=1.2.3 pycvp=4.5.6" in caplog.text
 
 
 async def test_network_failure_raises_updatefailed(
-    hass: HomeAssistant, pv_library: ModuleType
+    hass: HomeAssistant,
+    pv_library: ModuleType,
+    monkeypatch: MonkeyPatch,
+    caplog: LogCaptureFixture,
 ) -> None:
     """Network failures should raise UpdateFailed."""
     entry = _create_entry(auto_end=False)
@@ -121,6 +137,10 @@ async def test_network_failure_raises_updatefailed(
 
     provider = AsyncMock()
     provider.get_permit.side_effect = pv_library.NetworkError
+    monkeypatch.setattr(
+        "custom_components.city_visitor_parking.coordinator.async_get_versions",
+        AsyncMock(return_value=("1.2.3", "4.5.6")),
+    )
 
     coordinator = CityVisitorParkingCoordinator(
         hass,
@@ -130,8 +150,12 @@ async def test_network_failure_raises_updatefailed(
         auto_end_state=AutoEndState(),
     )
 
-    await coordinator.async_refresh()
+    with caplog.at_level(
+        logging.DEBUG, logger="custom_components.city_visitor_parking.coordinator"
+    ):
+        await coordinator.async_refresh()
     assert isinstance(coordinator.last_exception, UpdateFailed)
+    assert "hacvp=1.2.3 pycvp=4.5.6" in caplog.text
 
 
 async def test_unexpected_failure_raises_updatefailed(hass: HomeAssistant) -> None:

--- a/tests/components/city_visitor_parking/test_coordinator.py
+++ b/tests/components/city_visitor_parking/test_coordinator.py
@@ -122,7 +122,7 @@ async def test_auth_failure_triggers_reauth(
     ):
         await coordinator.async_refresh()
     assert isinstance(coordinator.last_exception, ConfigEntryAuthFailed)
-    assert "hacvp=1.2.3 pycvp=4.5.6" in caplog.text
+    assert "hacvp=1.2.3, pycvp=4.5.6" in caplog.text
 
 
 async def test_network_failure_raises_updatefailed(
@@ -155,7 +155,7 @@ async def test_network_failure_raises_updatefailed(
     ):
         await coordinator.async_refresh()
     assert isinstance(coordinator.last_exception, UpdateFailed)
-    assert "hacvp=1.2.3 pycvp=4.5.6" in caplog.text
+    assert "hacvp=1.2.3, pycvp=4.5.6" in caplog.text
 
 
 async def test_unexpected_failure_raises_updatefailed(hass: HomeAssistant) -> None:

--- a/tests/components/city_visitor_parking/test_entities.py
+++ b/tests/components/city_visitor_parking/test_entities.py
@@ -73,6 +73,23 @@ async def test_entity_unique_id_and_device_info() -> None:
     assert (DOMAIN, entry_two.entry_id) in device_info_two["identifiers"]
 
 
+async def test_entity_device_info_includes_configuration_url() -> None:
+    """Entities should expose the provider GUI URL in device info."""
+    coordinator = _make_coordinator(_sample_data())
+    entry = _create_entry("provider:permit1:city")
+    entry.runtime_data = SimpleNamespace(
+        provider_config=SimpleNamespace(
+            gui_url="https://parkeren.rijswijk.nl/DVSPortal/"
+        )
+    )
+
+    sensor = ActiveReservationsSensor(coordinator, entry)
+
+    device_info = sensor.device_info
+    assert device_info is not None
+    assert device_info["configuration_url"] == "https://parkeren.rijswijk.nl/DVSPortal/"
+
+
 async def test_zone_availability_uses_overrides() -> None:
     """Zone availability should reflect overrides for the current day."""
     now = datetime(2025, 1, 6, 9, 30, tzinfo=UTC)

--- a/tests/components/city_visitor_parking/test_init.py
+++ b/tests/components/city_visitor_parking/test_init.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 from types import SimpleNamespace
 from typing import TYPE_CHECKING
@@ -36,7 +37,7 @@ if TYPE_CHECKING:
     from types import ModuleType
 
     from homeassistant.core import HomeAssistant
-    from pytest import MonkeyPatch
+    from pytest import LogCaptureFixture, MonkeyPatch
 
 
 async def test_async_setup_entry_auth_error(
@@ -180,7 +181,9 @@ async def test_register_frontend_assets_missing_dist(
 
 
 async def test_register_frontend_assets_missing_translations(
-    hass: HomeAssistant, monkeypatch: MonkeyPatch
+    hass: HomeAssistant,
+    monkeypatch: MonkeyPatch,
+    caplog: LogCaptureFixture,
 ) -> None:
     """Frontend assets should warn when translations are missing."""
     hass.config.components.add("frontend")
@@ -194,11 +197,18 @@ async def test_register_frontend_assets_missing_translations(
         return original_is_dir(self)
 
     monkeypatch.setattr(Path, "is_dir", _fake_is_dir)
+    monkeypatch.setattr(
+        init_module, "async_get_versions", AsyncMock(return_value=("1.2.3", "4.5.6"))
+    )
 
-    await init_module._async_register_frontend(hass, "frontend")
+    with caplog.at_level(
+        logging.WARNING, logger="custom_components.city_visitor_parking"
+    ):
+        await init_module._async_register_frontend(hass, "frontend")
 
     hass.http.async_register_static_paths.assert_awaited_once()
     assert hass.data[DOMAIN]["frontend_registered"] is True
+    assert "hacvp=1.2.3 pycvp=4.5.6" in caplog.text
 
 
 async def test_register_lovelace_resources_non_storage(

--- a/tests/components/city_visitor_parking/test_init.py
+++ b/tests/components/city_visitor_parking/test_init.py
@@ -208,7 +208,7 @@ async def test_register_frontend_assets_missing_translations(
 
     hass.http.async_register_static_paths.assert_awaited_once()
     assert hass.data[DOMAIN]["frontend_registered"] is True
-    assert "hacvp=1.2.3 pycvp=4.5.6" in caplog.text
+    assert "hacvp=1.2.3, pycvp=4.5.6" in caplog.text
 
 
 async def test_register_lovelace_resources_non_storage(

--- a/tests/components/city_visitor_parking/test_services.py
+++ b/tests/components/city_visitor_parking/test_services.py
@@ -413,7 +413,7 @@ async def test_service_start_reservation_error(
             },
             blocking=True,
         )
-    assert "hacvp=1.2.3 pycvp=4.5.6" in caplog.text
+    assert "hacvp=1.2.3, pycvp=4.5.6" in caplog.text
 
 
 async def test_update_reservation_requires_full_details(
@@ -603,7 +603,7 @@ async def test_service_add_favorite_error(
             },
             blocking=True,
         )
-    assert "hacvp=1.2.3 pycvp=4.5.6" in caplog.text
+    assert "hacvp=1.2.3, pycvp=4.5.6" in caplog.text
 
 
 async def test_service_update_favorite_requires_changes(
@@ -768,11 +768,15 @@ async def test_service_invalid_entry_state(hass: HomeAssistant) -> None:
 
 
 async def test_fallback_update_reservation_error(
-    hass: HomeAssistant, pv_library: ModuleType
+    hass: HomeAssistant, pv_library: ModuleType, monkeypatch: MonkeyPatch
 ) -> None:
     """Fallback update reservation errors should raise HomeAssistantError."""
     entry, _device, provider = _create_entry_with_device(hass, "permit1")
     provider.end_reservation.side_effect = pv_library.ProviderError("boom")
+    monkeypatch.setattr(
+        "custom_components.city_visitor_parking.services.async_get_versions",
+        AsyncMock(return_value=("1.2.3", "4.5.6")),
+    )
 
     start = datetime.now(UTC)
     end = start + timedelta(hours=1)
@@ -797,10 +801,16 @@ async def test_fallback_update_favorite_validation_error(
         await _fallback_update_favorite(entry.runtime_data, "fav1", None, None)
 
 
-async def test_fallback_update_favorite_error(hass: HomeAssistant) -> None:
+async def test_fallback_update_favorite_error(
+    hass: HomeAssistant, monkeypatch: MonkeyPatch
+) -> None:
     """Fallback update favorite errors should raise HomeAssistantError."""
     entry, _device, provider = _create_entry_with_device(hass, "permit1")
     provider.add_favorite.side_effect = TypeError("boom")
+    monkeypatch.setattr(
+        "custom_components.city_visitor_parking.services.async_get_versions",
+        AsyncMock(return_value=("1.2.3", "4.5.6")),
+    )
 
     with pytest.raises(HomeAssistantError):
         await _fallback_update_favorite(

--- a/tests/components/city_visitor_parking/test_services.py
+++ b/tests/components/city_visitor_parking/test_services.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from datetime import UTC, datetime, time, timedelta
 from types import SimpleNamespace
 from typing import TYPE_CHECKING
@@ -70,6 +71,7 @@ if TYPE_CHECKING:
     from types import ModuleType
 
     from homeassistant.core import HomeAssistant
+    from pytest import LogCaptureFixture, MonkeyPatch
 
 EXPECTED_COUNT = 2
 EXPECTED_REMAINING_MINUTES = 90
@@ -376,18 +378,30 @@ async def test_service_start_reservation_adjusts_start(hass: HomeAssistant) -> N
 
 
 async def test_service_start_reservation_error(
-    hass: HomeAssistant, pv_library: ModuleType
+    hass: HomeAssistant,
+    pv_library: ModuleType,
+    monkeypatch: MonkeyPatch,
+    caplog: LogCaptureFixture,
 ) -> None:
     """Start reservation errors should raise HomeAssistantError."""
     await async_setup_services(hass)
 
     _, device, provider = _create_entry_with_device(hass, "permit1")
     provider.start_reservation.side_effect = pv_library.ProviderError("boom")
+    monkeypatch.setattr(
+        "custom_components.city_visitor_parking.services.async_get_versions",
+        AsyncMock(return_value=("1.2.3", "4.5.6")),
+    )
 
     start = datetime.now(UTC)
     end = start + timedelta(hours=1)
 
-    with pytest.raises(HomeAssistantError):
+    with (
+        caplog.at_level(
+            logging.DEBUG, logger="custom_components.city_visitor_parking.services"
+        ),
+        pytest.raises(HomeAssistantError),
+    ):
         await hass.services.async_call(
             DOMAIN,
             SERVICE_START_RESERVATION,
@@ -399,6 +413,7 @@ async def test_service_start_reservation_error(
             },
             blocking=True,
         )
+    assert "hacvp=1.2.3 pycvp=4.5.6" in caplog.text
 
 
 async def test_update_reservation_requires_full_details(
@@ -558,14 +573,27 @@ async def test_service_end_reservation_error(
         )
 
 
-async def test_service_add_favorite_error(hass: HomeAssistant) -> None:
+async def test_service_add_favorite_error(
+    hass: HomeAssistant,
+    monkeypatch: MonkeyPatch,
+    caplog: LogCaptureFixture,
+) -> None:
     """Add favorite errors should raise HomeAssistantError."""
     await async_setup_services(hass)
 
     _, device, provider = _create_entry_with_device(hass, "permit1")
     provider.add_favorite.side_effect = TypeError("boom")
+    monkeypatch.setattr(
+        "custom_components.city_visitor_parking.services.async_get_versions",
+        AsyncMock(return_value=("1.2.3", "4.5.6")),
+    )
 
-    with pytest.raises(HomeAssistantError):
+    with (
+        caplog.at_level(
+            logging.DEBUG, logger="custom_components.city_visitor_parking.services"
+        ),
+        pytest.raises(HomeAssistantError),
+    ):
         await hass.services.async_call(
             DOMAIN,
             SERVICE_ADD_FAVORITE,
@@ -575,6 +603,7 @@ async def test_service_add_favorite_error(hass: HomeAssistant) -> None:
             },
             blocking=True,
         )
+    assert "hacvp=1.2.3 pycvp=4.5.6" in caplog.text
 
 
 async def test_service_update_favorite_requires_changes(

--- a/tests/components/city_visitor_parking/test_version.py
+++ b/tests/components/city_visitor_parking/test_version.py
@@ -1,0 +1,55 @@
+"""Tests for shared version helpers."""
+
+from __future__ import annotations
+
+import importlib.metadata
+from types import SimpleNamespace
+from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock
+
+from custom_components.city_visitor_parking.version import (
+    _VERSION_CACHE_KEY,
+    async_get_versions,
+)
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
+    from pytest import MonkeyPatch
+
+
+async def test_async_get_versions_returns_versions(
+    hass: HomeAssistant, monkeypatch: MonkeyPatch
+) -> None:
+    """Version helper should return manifest and package versions."""
+    hass.data.pop(_VERSION_CACHE_KEY, None)
+    monkeypatch.setattr(
+        "custom_components.city_visitor_parking.version.async_get_integration",
+        AsyncMock(return_value=SimpleNamespace(manifest={"version": "1.2.3"})),
+    )
+    monkeypatch.setattr(
+        "custom_components.city_visitor_parking.version.importlib.metadata.version",
+        lambda _: "4.5.6",
+    )
+
+    assert await async_get_versions(hass) == ("1.2.3", "4.5.6")
+
+
+async def test_async_get_versions_handles_missing_package(
+    hass: HomeAssistant, monkeypatch: MonkeyPatch
+) -> None:
+    """Version helper should fall back to unknown when package metadata is missing."""
+    hass.data.pop(_VERSION_CACHE_KEY, None)
+    monkeypatch.setattr(
+        "custom_components.city_visitor_parking.version.async_get_integration",
+        AsyncMock(return_value=SimpleNamespace(manifest={"version": "1.2.3"})),
+    )
+
+    def _raise_package_not_found(_: str) -> str:
+        raise importlib.metadata.PackageNotFoundError
+
+    monkeypatch.setattr(
+        "custom_components.city_visitor_parking.version.importlib.metadata.version",
+        _raise_package_not_found,
+    )
+
+    assert await async_get_versions(hass) == ("1.2.3", "unknown")


### PR DESCRIPTION
## Summary
- simplify the setup flow to select a municipality and authenticate in one step with typed municipality resolution
- add shared integration/library version logging and pass version metadata through setup, config flow, coordinator, and services
- expand provider metadata support and tests for the new flow and version helpers

## Notes
- `.vscode` changes were intentionally left out of this PR
- local commit skipped `mypy`, `pyright`, and `pytest` hooks because those modules were unavailable in `/usr/local/bin/python`; the remaining formatting and lint hooks passed