### PR TITLE
Prepare 0.1.34-beta.1 test release

### DIFF
--- a/custom_components/city_visitor_parking/manifest.json
+++ b/custom_components/city_visitor_parking/manifest.json
@@ -10,6 +10,6 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/sir-Unknown/ha_City-Visitor-Parking/issues",
   "quality_scale": "platinum",
-  "requirements": ["pycityvisitorparking==0.5.19"],
+  "requirements": ["pycityvisitorparking==0.5.20"],
   "version": "0.0.0"
 }

--- a/custom_components/city_visitor_parking/manifest.json
+++ b/custom_components/city_visitor_parking/manifest.json
@@ -10,6 +10,8 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/sir-Unknown/ha_City-Visitor-Parking/issues",
   "quality_scale": "platinum",
-  "requirements": ["pycityvisitorparking==0.5.20"],
-  "version": "0.0.0"
+  "requirements": [
+    "pycityvisitorparking @ git+https://github.com/sir-Unknown/pyCityVisitorParking.git@3627783b8557fdbdd0863db8924d6336f5ab1858"
+  ],
+  "version": "0.1.34-beta.1"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "ha-city-visitor-parking"
 version = "0.0.0"
 requires-python = ">=3.14.2"
-dependencies = ["pycityvisitorparking==0.5.19"]
+dependencies = ["pycityvisitorparking==0.5.20"]
 
 [dependency-groups]
 dev = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "ha-city-visitor-parking"
 version = "0.0.0"
 requires-python = ">=3.14.2"
-dependencies = ["pycityvisitorparking==0.5.20"]
+dependencies = ["pycityvisitorparking @ git+https://github.com/sir-Unknown/pyCityVisitorParking.git@3627783b8557fdbdd0863db8924d6336f5ab1858"]
 
 [dependency-groups]
 dev = [

--- a/uv.lock
+++ b/uv.lock
@@ -909,7 +909,7 @@ test = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "pycityvisitorparking", specifier = "==0.5.20" }]
+requires-dist = [{ name = "pycityvisitorparking", git = "https://github.com/sir-Unknown/pyCityVisitorParking.git?rev=3627783b8557fdbdd0863db8924d6336f5ab1858" }]
 
 [package.metadata.requires-dev]
 dev = [
@@ -1609,14 +1609,10 @@ wheels = [
 
 [[package]]
 name = "pycityvisitorparking"
-version = "0.5.20"
-source = { registry = "https://pypi.org/simple" }
+version = "0.5.21.dev4+g3627783b8"
+source = { git = "https://github.com/sir-Unknown/pyCityVisitorParking.git?rev=3627783b8557fdbdd0863db8924d6336f5ab1858#3627783b8557fdbdd0863db8924d6336f5ab1858" }
 dependencies = [
     { name = "aiohttp" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/1c/28/6aa77a8439263ec53303c3d2954b39fff738ab30694c6b24690879b01ffd/pycityvisitorparking-0.5.20.tar.gz", hash = "sha256:8e67355be6c8ec6fd0a06f168035798ee48f6634569e205429a0ab60fbcc991c", size = 62483, upload-time = "2026-04-10T00:49:00.008Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/54/68/d3a86fe5909efd2cb6ec880d672a02f588f265fdac06db98a7ea48a740e2/pycityvisitorparking-0.5.20-py3-none-any.whl", hash = "sha256:9d338e6241ba3d6d00f059e58142e43f9914fee67cecf40149822a18dd186c11", size = 58002, upload-time = "2026-04-10T00:48:58.694Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -909,7 +909,7 @@ test = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "pycityvisitorparking", specifier = "==0.5.19" }]
+requires-dist = [{ name = "pycityvisitorparking", specifier = "==0.5.20" }]
 
 [package.metadata.requires-dev]
 dev = [
@@ -1609,14 +1609,14 @@ wheels = [
 
 [[package]]
 name = "pycityvisitorparking"
-version = "0.5.19"
+version = "0.5.20"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b0/41/c0a4b987f774a3742a6875763b46bfe64166a45fb62286b50e288b090baa/pycityvisitorparking-0.5.19.tar.gz", hash = "sha256:2189131aee24053dcd2e18d658fdc10713bea978615abed4a2edf5b739fac4d1", size = 64178, upload-time = "2026-04-08T20:57:09.162Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1c/28/6aa77a8439263ec53303c3d2954b39fff738ab30694c6b24690879b01ffd/pycityvisitorparking-0.5.20.tar.gz", hash = "sha256:8e67355be6c8ec6fd0a06f168035798ee48f6634569e205429a0ab60fbcc991c", size = 62483, upload-time = "2026-04-10T00:49:00.008Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c1/da/863ff97db7c40778462838993d1ef436760275d2d7e6a0c4cc1a7ee48cef/pycityvisitorparking-0.5.19-py3-none-any.whl", hash = "sha256:fd4c827ac56d14854d4d390c1aa73d88e3a47b316e739f2af5cc6ea88daf3f45", size = 58066, upload-time = "2026-04-08T20:57:07.045Z" },
+    { url = "https://files.pythonhosted.org/packages/54/68/d3a86fe5909efd2cb6ec880d672a02f588f265fdac06db98a7ea48a740e2/pycityvisitorparking-0.5.20-py3-none-any.whl", hash = "sha256:9d338e6241ba3d6d00f059e58142e43f9914fee67cecf40149822a18dd186c11", size = 58002, upload-time = "2026-04-10T00:48:58.694Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What changed
This prepares a temporary `0.1.34-beta.1` test release for the Home Assistant integration.

## Why
`pycityvisitorparking==0.5.21` is not yet available on PyPI, but we want to test the DVS Portal login fix end-to-end in Home Assistant.

## Implementation
- bump the integration manifest version to `0.1.34-beta.1`
- replace the PyPI dependency pin with a git-based requirement pointing to `pyCityVisitorParking` commit `3627783b8557fdbdd0863db8924d6336f5ab1858`
- refresh `uv.lock` to resolve against that exact commit

## Notes
This is intended as a temporary test/prerelease path only. Once `pycityvisitorparking 0.5.21` is published on PyPI, the integration should be switched back to a normal version pin before a final public release.

## Validation
- `uv lock`
- local dependency resolution against `pyCityVisitorParking` commit `3627783b8557fdbdd0863db8924d6336f5ab1858`

## Out of scope
Uncommitted local changes in `custom_components/city_visitor_parking/config_flow.py` and `.vscode/settings.json` are not part of this PR.