### PR TITLE
Pin pycityvisitorparking to 0.5.21

### DIFF
--- a/custom_components/city_visitor_parking/manifest.json
+++ b/custom_components/city_visitor_parking/manifest.json
@@ -10,8 +10,6 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/sir-Unknown/ha_City-Visitor-Parking/issues",
   "quality_scale": "platinum",
-  "requirements": [
-    "pycityvisitorparking @ git+https://github.com/sir-Unknown/pyCityVisitorParking.git@3627783b8557fdbdd0863db8924d6336f5ab1858"
-  ],
+  "requirements": ["pycityvisitorparking==0.5.21"],
   "version": "0.1.34-beta.1"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "ha-city-visitor-parking"
 version = "0.0.0"
 requires-python = ">=3.14.2"
-dependencies = ["pycityvisitorparking @ git+https://github.com/sir-Unknown/pyCityVisitorParking.git@3627783b8557fdbdd0863db8924d6336f5ab1858"]
+dependencies = ["pycityvisitorparking==0.5.21"]
 
 [dependency-groups]
 dev = [

--- a/uv.lock
+++ b/uv.lock
@@ -909,7 +909,7 @@ test = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "pycityvisitorparking", git = "https://github.com/sir-Unknown/pyCityVisitorParking.git?rev=3627783b8557fdbdd0863db8924d6336f5ab1858" }]
+requires-dist = [{ name = "pycityvisitorparking", specifier = "==0.5.21" }]
 
 [package.metadata.requires-dev]
 dev = [
@@ -1609,10 +1609,14 @@ wheels = [
 
 [[package]]
 name = "pycityvisitorparking"
-version = "0.5.21.dev4+g3627783b8"
-source = { git = "https://github.com/sir-Unknown/pyCityVisitorParking.git?rev=3627783b8557fdbdd0863db8924d6336f5ab1858#3627783b8557fdbdd0863db8924d6336f5ab1858" }
+version = "0.5.21"
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6a/55/2b2ceb8cd96eaff14141726455350d6249e3151a34fe6f46906cdad6d01b/pycityvisitorparking-0.5.21.tar.gz", hash = "sha256:848909b17ecc44592f84f15db51e512b3a9017dacc9f11816b116e3b1be0c23d", size = 62789, upload-time = "2026-04-10T17:47:46.539Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/83/98/481a52122724f3de497b145f27c6066f306076ad505c85a7820dd8c5b4db/pycityvisitorparking-0.5.21-py3-none-any.whl", hash = "sha256:33cfaf7281474f36bd677b516650098b68ba658469c2cc2b078a1682166d8010", size = 58293, upload-time = "2026-04-10T17:47:45.082Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What changed
This replaces the temporary git-based `pycityvisitorparking` dependency with the published PyPI release `0.5.21`.

## Why
The previous testrelease path pinned `pycityvisitorparking` to a specific Git commit so the DVS Portal fix could be tested before release. Now that `0.5.21` is available on PyPI, the integration can switch back to a normal version pin.

## Implementation
- update `custom_components/city_visitor_parking/manifest.json` to `pycityvisitorparking==0.5.21`
- update `pyproject.toml` to `pycityvisitorparking==0.5.21`
- refresh `uv.lock` against the published PyPI package

## Validation
- `uv lock`
- dependency resolution updated from git source to PyPI `0.5.21`

## Notes
This PR intentionally leaves the existing integration version field unchanged and only normalizes the dependency source.