### PR TITLE
feat: add testing branch CI/CD support

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -9,6 +9,11 @@ tests:
       - any-glob-to-any-file:
           - "tests/**"
 
+ci:
+  - changed-files:
+      - any-glob-to-any-file:
+          - ".github/workflows/**"
+
 maintenance:
   - changed-files:
       - any-glob-to-any-file:

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -9,6 +9,9 @@ tests:
       - any-glob-to-any-file:
           - "tests/**"
 
+testing:
+  - head-branch: ["testing"]
+
 ci:
   - changed-files:
       - any-glob-to-any-file:

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -4,7 +4,7 @@
   description: "A breaking change for existing users."
 - name: "bugfix"
   color: ee0701
-  description: "Inconsistencies or issues which will cause a problem for users or implementors."
+  description: "Inconsistencies or issues which will cause a problem for users or implementers."
 - name: "documentation"
   color: 0052cc
   description: "Solely about the documentation of the project."
@@ -74,3 +74,6 @@
 - name: "minor"
   color: 0e8a16
   description: "This PR causes a minor version bump in the version number."
+- name: "testing"
+  color: fbca04
+  description: "Related to the testing branch or pre-release testing."

--- a/.github/release-drafter-testing.yml
+++ b/.github/release-drafter-testing.yml
@@ -1,0 +1,74 @@
+name-template: "v$RESOLVED_VERSION-beta"
+tag-template: "v$RESOLVED_VERSION-beta"
+commitish: "testing"
+change-template: "- $TITLE @$AUTHOR (#$NUMBER)"
+no-changes-template: "- No changes"
+sort-direction: ascending
+include-paths:
+  - "custom_components/**"
+categories:
+  - title: "🚨 Breaking changes"
+    labels:
+      - "breaking-change"
+  - title: "✨ New features"
+    labels:
+      - "new-feature"
+  - title: "🐛 Bug fixes"
+    labels:
+      - "bugfix"
+  - title: "🚀 Enhancements"
+    labels:
+      - "enhancement"
+      - "refactor"
+      - "performance"
+  - title: "🧰 Maintenance"
+    labels:
+      - "maintenance"
+      - "ci"
+  - title: "⬆️ Dependency updates"
+    labels:
+      - "dependencies"
+  - title: "🧪 Tests"
+    labels:
+      - "tests"
+  - title: "📚 Documentation"
+    labels:
+      - "documentation"
+version-resolver:
+  major:
+    labels:
+      - "major"
+      - "breaking-change"
+  minor:
+    labels:
+      - "minor"
+      - "new-feature"
+  patch:
+    labels:
+      - "bugfix"
+      - "ci"
+      - "dependencies"
+      - "documentation"
+      - "enhancement"
+      - "maintenance"
+      - "performance"
+      - "refactor"
+      - "tests"
+  default: patch
+autolabeler:
+  - label: "documentation"
+    files:
+      - "**/*.md"
+      - "docs/**"
+  - label: "tests"
+    files:
+      - "tests/**"
+  - label: "maintenance"
+    files:
+      - ".github/**"
+template: |
+  # 🚗 City Visitor Parking (pre-release)
+
+  $CHANGES
+
+  # 🚗 City Visitor Parking (pre-release)

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,20 @@
+---
+name: Labeler
+
+# yamllint disable-line rule:truthy
+on:
+  pull_request_target: # zizmor: ignore[dangerous-triggers] This workflow only applies labels based on changed files.
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  labeler:
+    name: Apply labels
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5.0.0
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - main
+      - testing
     paths:
       - custom_components/**
   pull_request:
@@ -23,8 +24,17 @@ jobs:
         if: github.event_name == 'pull_request'
         run: echo "PR check only; release drafts are updated on pushes to main."
 
-      - name: Run Release Drafter
-        if: github.event_name != 'pull_request'
+      - name: Run Release Drafter (stable)
+        if: github.event_name != 'pull_request' && github.ref_name == 'main'
         uses: release-drafter/release-drafter@139054aeaa9adc52ab36ddf67437541f039b88e2 # v7.1.1
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+
+      - name: Run Release Drafter (pre-release)
+        if: github.event_name != 'pull_request' && github.ref_name == 'testing'
+        uses: release-drafter/release-drafter@139054aeaa9adc52ab36ddf67437541f039b88e2 # v7.1.1
+        with:
+          config-name: release-drafter-testing.yml
+          prerelease: true
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -151,12 +151,16 @@ jobs:
                   time.sleep(10)
           PYEOF
           ) || exit 0
-          MANIFEST=$(python3 -c "
-          import json
+          MANIFEST=$(python3 - <<'PYEOF'
+          import json, sys
           data = json.load(open('custom_components/city_visitor_parking/manifest.json'))
-          pkg = next(r for r in data['requirements'] if r.startswith('pycityvisitorparking=='))
+          pkg = next((r for r in data['requirements'] if r.startswith('pycityvisitorparking==')), None)
+          if pkg is None:
+              print("::warning::manifest.json uses a non-PyPI requirement for pycityvisitorparking — skipping version check.", file=sys.stderr)
+              sys.exit(2)
           print(pkg.split('==')[1])
-          ")
+          PYEOF
+          ) || exit 0
           echo "Latest on PyPI : $LATEST"
           echo "In manifest.json: $MANIFEST"
           if [ "$LATEST" != "$MANIFEST" ]; then

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -5,7 +5,7 @@ on:
   schedule:
     - cron: "0 3 * * *"
   push:
-    branches: [main]
+    branches: [main, testing]
     tags:
       - "*"
     paths-ignore:
@@ -56,6 +56,7 @@ jobs:
   hassfest:
     name: Hassfest validation
     needs: [ruff]
+    if: ${{ github.ref_name != 'testing' && !(contains(github.ref_name, '-beta') || contains(github.ref_name, '-rc') || contains(github.ref_name, '-alpha')) }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
@@ -71,6 +72,7 @@ jobs:
   hacs:
     name: HACS validation
     needs: [ruff]
+    if: ${{ github.ref_name != 'testing' && !(contains(github.ref_name, '-beta') || contains(github.ref_name, '-rc') || contains(github.ref_name, '-alpha')) }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
@@ -115,6 +117,7 @@ jobs:
 
   manifest-version:
     name: Manifest Python package version
+    if: ${{ github.ref_name != 'testing' && !(contains(github.ref_name, '-beta') || contains(github.ref_name, '-rc') || contains(github.ref_name, '-alpha')) }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:

--- a/custom_components/city_visitor_parking/config_flow.py
+++ b/custom_components/city_visitor_parking/config_flow.py
@@ -78,6 +78,10 @@ class CityVisitorParkingConfigFlow(config_entries.ConfigFlow):
         self._credentials: dict[str, str] = {}
         self._reauth_entry: config_entries.ConfigEntry | None = None
 
+    def is_matching(self, other_flow: CityVisitorParkingConfigFlow) -> bool:
+        """Return True if other_flow matches this flow."""
+        return False
+
     async def async_step_user(
         self, user_input: dict[str, object] | None = None
     ) -> config_entries.ConfigFlowResult:
@@ -119,7 +123,7 @@ class CityVisitorParkingConfigFlow(config_entries.ConfigFlow):
         return self.hass.config_entries.async_get_entry(entry_id)
 
     async def async_step_reauth(
-        self, user_input: dict[str, object] | None = None
+        self, _user_input: dict[str, object] | None = None
     ) -> config_entries.ConfigFlowResult:
         """Handle reauthentication."""
         entry = self._entry_from_context()
@@ -244,9 +248,9 @@ class CityVisitorParkingConfigFlow(config_entries.ConfigFlow):
                                 value=provider.municipality_name,
                                 label=provider.municipality_name,
                             )
-                            for key, provider in sorted(
-                                self._providers.items(),
-                                key=lambda item: item[1].municipality_name,
+                            for provider in sorted(
+                                self._providers.values(),
+                                key=lambda p: p.municipality_name,
                             )
                         ],
                         custom_value=True,
@@ -390,7 +394,7 @@ class CityVisitorParkingConfigFlow(config_entries.ConfigFlow):
             )
             error_key = "unknown"
         # Allowed in config flow
-        except Exception as err:
+        except Exception as err:  # pylint: disable=broad-exception-caught
             _LOGGER.debug(
                 "Unexpected error during login for %s: %s: %s %s",
                 self._provider_config.provider_id,


### PR DESCRIPTION
## Summary

- **validate.yml**: skip `hassfest`, `HACS validation` en `manifest-version` voor de `testing` branch en pre-release tags (`-beta`, `-rc`, `-alpha`); `testing` toegevoegd aan push trigger
- **release-drafter.yml**: aparte stap voor `testing` branch die een pre-release draft aanmaakt via `release-drafter-testing.yml`
- **release-drafter-testing.yml**: nieuwe config met `commitish: testing` en pre-release template
- **config_flow.py**: fix voor pyright error (ongebruikte loop-variabele `key`)

## Achtergrond

Geeft de mogelijkheid om test releases te doen vanaf de `testing` branch, inclusief releases met git-afhankelijkheden in `manifest.json` (voor het testen van nog niet gepubliceerde library versies), zonder dat `main` vervuild wordt.

## Gedrag per situatie

| | Ruff | Pytest | Frontend | Hassfest | HACS | Manifest-version |
|---|---|---|---|---|---|---|
| Push naar `testing` | ✅ | ✅ | ✅ | ⏭ | ⏭ | ⏭ |
| Tag `v0.x.x-beta.y` | ✅ | ✅ | ✅ | ⏭ | ⏭ | ⏭ |
| Tag `v0.x.x` (stable) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |

## Test plan

- [ ] Push naar `testing` branch → validate draait, hassfest/HACS/manifest-version worden geskipped
- [ ] Pre-release tag (`-beta`) aanmaken → release workflow slaagt
- [ ] Stabiele tag aanmaken vanaf `main` → alle checks draaien normaal

🤖 Generated with [Claude Code](https://claude.com/claude-code)