### PR TITLE
feat: add version input to release-drafter workflow_dispatch

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -10,6 +10,11 @@ on:
       - custom_components/**
   pull_request:
   workflow_dispatch:
+    inputs:
+      version:
+        description: "Version override (e.g. 0.1.35). Leave empty to auto-resolve from PR labels."
+        required: false
+        type: string
 
 permissions: {}
 
@@ -27,6 +32,8 @@ jobs:
       - name: Run Release Drafter (stable)
         if: github.event_name != 'pull_request' && github.ref_name == 'main'
         uses: release-drafter/release-drafter@139054aeaa9adc52ab36ddf67437541f039b88e2 # v7.1.1
+        with:
+          version: ${{ inputs.version }}
         env:
           GITHUB_TOKEN: ${{ github.token }}
 
@@ -36,5 +43,6 @@ jobs:
         with:
           config-name: release-drafter-testing.yml
           prerelease: true
+          version: ${{ inputs.version }}
         env:
           GITHUB_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## Summary
- Voegt een optionele `version` input toe aan de `workflow_dispatch` trigger van de release-drafter workflow
- Bij handmatige run kan een versie worden opgegeven (bijv. `0.1.35`); leeg laten = auto-resolve via PR-labels
- Geldt voor zowel de stable (main) als pre-release (testing) drafter stap

## Test plan
- [ ] Handmatig triggeren zonder versie → versie wordt automatisch bepaald via PR-labels
- [ ] Handmatig triggeren met versie → opgegeven versie wordt gebruikt in de draft

🤖 Generated with [Claude Code](https://claude.com/claude-code)