### PR TITLE
chore: improve release workflows and draft templates

### DIFF
--- a/.github/release-drafter-testing.yml
+++ b/.github/release-drafter-testing.yml
@@ -1,8 +1,12 @@
-name-template: "v$RESOLVED_VERSION-beta"
-tag-template: "v$RESOLVED_VERSION-beta"
+name-template: "v$RESOLVED_VERSION"
+tag-template: "v$RESOLVED_VERSION"
 commitish: "testing"
 change-template: "- $TITLE @$AUTHOR (#$NUMBER)"
-no-changes-template: "- No changes"
+no-changes-template: "- No changes in `custom_components/**` since the last release."
+exclude-labels:
+  - "skip-changelog"
+  - "duplicate"
+  - "invalid"
 sort-direction: ascending
 include-paths:
   - "custom_components/**"
@@ -34,27 +38,6 @@ categories:
   - title: "📚 Documentation"
     labels:
       - "documentation"
-version-resolver:
-  major:
-    labels:
-      - "major"
-      - "breaking-change"
-  minor:
-    labels:
-      - "minor"
-      - "new-feature"
-  patch:
-    labels:
-      - "bugfix"
-      - "ci"
-      - "dependencies"
-      - "documentation"
-      - "enhancement"
-      - "maintenance"
-      - "performance"
-      - "refactor"
-      - "tests"
-  default: patch
 autolabeler:
   - label: "documentation"
     files:
@@ -67,8 +50,45 @@ autolabeler:
     files:
       - ".github/**"
 template: |
-  # 🚗 City Visitor Parking (pre-release)
+  > [!WARNING]
+  > **This is a testing release and is highly unstable.**
+  > It may contain breaking changes, incomplete features, or regressions.
+  > **Only install this if you were explicitly asked to by the maintainer.**
+  > Do not use this in a production Home Assistant environment.
+
+  ## 🔗 pyCityVisitorParking
+
+  **Commit:** `FILL_IN_COMMIT_SHA`
+
+  ## 📋 Changes
 
   $CHANGES
 
-  # 🚗 City Visitor Parking (pre-release)
+  ## 📦 Installation
+
+  In HACS, go to **City Visitor Parking** → **⋮** → **Redownload** → select this version from the version dropdown.
+
+  ## 🔁 Rollback
+
+  If something breaks, reinstall the latest stable release the same way: **HACS** → **City Visitor Parking** → **⋮** → **Redownload** → select the stable version.
+
+  ## 🪲 Enable debug logging
+
+  To help with testing, add the following to your `configuration.yaml` and restart Home Assistant:
+
+  ```yaml
+  logger:
+    default: info
+    logs:
+      custom_components.city_visitor_parking: debug
+      pycityvisitorparking.provider: debug
+      pycityvisitorparking.provider.dvsportal_new: debug
+  ```
+
+  ## 🐛 Reporting issues
+
+  Before opening an issue, download the diagnostics file via **Settings** → **Devices & services** → **City Visitor Parking** → **⋮** → **Download diagnostics**, and attach it to your report.
+
+  [![Open an issue](https://img.shields.io/badge/Report%20a%20bug-red?logo=github)](https://github.com/sir-Unknown/ha_City-Visitor-Parking/issues/new)
+
+  Include the release version, a description of the problem, relevant logs, and the diagnostics file if available.

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -2,7 +2,11 @@ name-template: "v$RESOLVED_VERSION"
 tag-template: "v$RESOLVED_VERSION"
 commitish: "main"
 change-template: "- $TITLE @$AUTHOR (#$NUMBER)"
-no-changes-template: "- No changes"
+no-changes-template: "- No changes in `custom_components/**` since the last release."
+exclude-labels:
+  - "skip-changelog"
+  - "duplicate"
+  - "invalid"
 sort-direction: ascending
 include-paths:
   - "custom_components/**"
@@ -67,8 +71,20 @@ autolabeler:
     files:
       - ".github/**"
 template: |
-  # 🚗 City Visitor Parking
+  🚗 City Visitor Parking is a Home Assistant integration that lets you register visitor parking permits directly from your dashboard.
+
+  ## 📋 Changes
 
   $CHANGES
 
-  # 🚗 City Visitor Parking
+  ## 📦 Installation
+
+  [![Open in HACS](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=sir-Unknown&repository=ha_City-Visitor-Parking&category=integration)
+
+  ## 📚 Documentation
+
+  See the [README](https://github.com/sir-Unknown/ha_City-Visitor-Parking#readme) for setup instructions and configuration options.
+
+  ## 🐛 Reporting issues
+
+  [![Open an issue](https://img.shields.io/badge/Report%20a%20bug-red?logo=github)](https://github.com/sir-Unknown/ha_City-Visitor-Parking/issues/new)

--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -2,7 +2,7 @@ name: Lock
 
 on:
   schedule:
-    - cron: "0 * * * *"
+    - cron: "0 1 * * *"
   workflow_dispatch:
 
 permissions: {}

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -8,15 +8,22 @@ on:
       - testing
     paths:
       - custom_components/**
-  pull_request:
   workflow_dispatch:
     inputs:
       version:
-        description: "Version override (e.g. 0.1.35). Leave empty to auto-resolve from PR labels."
+        description: "Version override (e.g. 0.1.35). Leave empty to auto-resolve from manifest.json."
+        required: false
+        type: string
+      suffix:
+        description: "Build metadata suffix (e.g. dvsportal_new). Leave empty to omit."
         required: false
         type: string
 
 permissions: {}
+
+concurrency:
+  group: release-drafter-${{ github.ref_name }}
+  cancel-in-progress: false
 
 jobs:
   update_release_draft:
@@ -25,24 +32,50 @@ jobs:
     permissions:
       contents: write
     steps:
-      - name: Acknowledge PR check
-        if: github.event_name == 'pull_request'
-        run: echo "PR check only; release drafts are updated on pushes to main."
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
 
       - name: Run Release Drafter (stable)
-        if: github.event_name != 'pull_request' && github.ref_name == 'main'
+        if: github.ref_name == 'main'
         uses: release-drafter/release-drafter@139054aeaa9adc52ab36ddf67437541f039b88e2 # v7.1.1
         with:
           version: ${{ inputs.version }}
         env:
           GITHUB_TOKEN: ${{ github.token }}
 
+      - name: Get next testing version
+        if: github.ref_name == 'testing'
+        id: next_version
+        env:
+          GH_TOKEN: ${{ github.token }}
+          INPUT_VERSION: ${{ inputs.version }}
+          INPUT_SUFFIX: ${{ inputs.suffix }}
+        run: |
+          if [ -n "${INPUT_VERSION}" ]; then
+            BASE="${INPUT_VERSION}"
+          else
+            BASE=$(jq -r '.version' custom_components/city_visitor_parking/manifest.json | sed 's/-.*//')
+          fi
+          LAST=$(gh release list --limit 1000 --json tagName --jq '.[].tagName' \
+            | grep -E "^v${BASE}-testing\.[0-9]+(\+.*)?$" \
+            | grep -oE "testing\.[0-9]+" \
+            | grep -oE "[0-9]+$" \
+            | sort -n | tail -1)
+          NEXT=$((${LAST:-0} + 1))
+          if [ -n "${INPUT_SUFFIX}" ]; then
+            echo "version=${BASE}-testing.${NEXT}+${INPUT_SUFFIX}" >> "$GITHUB_OUTPUT"
+          else
+            echo "version=${BASE}-testing.${NEXT}" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Run Release Drafter (pre-release)
-        if: github.event_name != 'pull_request' && github.ref_name == 'testing'
+        if: github.ref_name == 'testing'
         uses: release-drafter/release-drafter@139054aeaa9adc52ab36ddf67437541f039b88e2 # v7.1.1
         with:
           config-name: release-drafter-testing.yml
           prerelease: true
-          version: ${{ inputs.version }}
+          version: ${{ steps.next_version.outputs.version }}
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -206,10 +206,10 @@ jobs:
           data["version"] = os.environ["VERSION"]
           pycvp_commit = os.environ.get("PYCVP_COMMIT", "")
           if pycvp_commit:
-              data["requirements"] = [
-                  re.sub(r'[a-f0-9]{40}$', pycvp_commit, r)
-                  for r in data["requirements"]
-              ]
+              new_reqs = [re.sub(r'[a-f0-9]{40}$', pycvp_commit, r) for r in data["requirements"]]
+              if new_reqs == data["requirements"]:
+                  raise ValueError("No pyCityVisitorParking SHA found in requirements to replace")
+              data["requirements"] = new_reqs
           p.write_text(json.dumps(data, indent=2) + "\n")
           PYEOF
           cd /tmp/release-build && zip -r "$GITHUB_WORKSPACE/city_visitor_parking.zip" .

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,7 +73,7 @@ jobs:
             const { data: releases } = await github.rest.repos.listReleases({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              per_page: 20,
+              per_page: 100,
             });
 
             const previousRelease = releases.find(
@@ -152,7 +152,7 @@ jobs:
     outputs:
       version: ${{ steps.version.outputs.version }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
           ref: ${{ needs.validate.outputs.release_sha }}
@@ -177,18 +177,39 @@ jobs:
           version="${RELEASE_TAG,,}"
           version="${version#v}"
           echo "version=$version" >> "$GITHUB_OUTPUT"
+      - name: Extract pyCityVisitorParking commit from release body
+        if: contains(github.event.release.tag_name, '-testing.')
+        id: pycvp
+        env:
+          RELEASE_BODY: ${{ github.event.release.body }}
+        run: |
+          COMMIT=$(echo "$RELEASE_BODY" | grep -oE '\*\*Commit:\*\* `([a-f0-9]{40})`' | grep -oE '[a-f0-9]{40}')
+          if [ -z "$COMMIT" ]; then
+            echo "::error::No pyCityVisitorParking commit found in release body. Fill in the 'Commit' field in the release draft."
+            exit 1
+          fi
+          echo "commit=$COMMIT" >> "$GITHUB_OUTPUT"
+          echo "Found pyCityVisitorParking commit: $COMMIT"
+
       - name: Build release asset
         env:
           VERSION: ${{ steps.version.outputs.version }}
+          PYCVP_COMMIT: ${{ steps.pycvp.outputs.commit }}
         run: |
           mkdir /tmp/release-build
           git -C custom_components/city_visitor_parking archive --format=tar \
             --worktree-attributes HEAD | tar -x -C /tmp/release-build
-          python3 - <<PYEOF
-          import json, pathlib
+          python3 - <<'PYEOF'
+          import json, os, pathlib, re
           p = pathlib.Path("/tmp/release-build/manifest.json")
           data = json.loads(p.read_text())
-          data["version"] = "$VERSION"
+          data["version"] = os.environ["VERSION"]
+          pycvp_commit = os.environ.get("PYCVP_COMMIT", "")
+          if pycvp_commit:
+              data["requirements"] = [
+                  re.sub(r'[a-f0-9]{40}$', pycvp_commit, r)
+                  for r in data["requirements"]
+              ]
           p.write_text(json.dumps(data, indent=2) + "\n")
           PYEOF
           cd /tmp/release-build && zip -r "$GITHUB_WORKSPACE/city_visitor_parking.zip" .
@@ -197,16 +218,6 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           RELEASE_TAG: ${{ github.event.release.tag_name }}
         run: gh release upload "$RELEASE_TAG" city_visitor_parking.zip --clobber
-      - name: Publish release
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
-        with:
-          script: |
-            await github.rest.repos.updateRelease({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              release_id: context.payload.release.id,
-              draft: false,
-            });
 
   skip-release:
     needs: [validate]

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -2,7 +2,7 @@ name: Stale
 
 on:
   schedule:
-    - cron: "0 * * * *"
+    - cron: "0 1 * * *"
   workflow_dispatch:
 
 permissions: {}


### PR DESCRIPTION
## Summary

- Add `release-drafter-testing.yml` with testing-specific template (warning block, debug logging, installation, rollback, diagnostics, issue reporting)
- Auto-increment testing version numbers using semver pre-release format (`0.1.34-testing.1+suffix`)
- Add `concurrency` control and remove unused `pull_request` trigger from release-drafter workflow
- Update `release.yml`: fix checkout version comment, increase `per_page` from 20 → 100, remove redundant "Publish release" step, fix Python heredoc shell injection, add pyCityVisitorParking commit field parsed from testing release body
- Improve stable release draft template with visual helpers (badges, emojis), installation and issue reporting

## Test plan

- [ ] Trigger release-drafter workflow on `testing` branch and verify draft is created as `vX.Y.Z-testing.1`
- [ ] Trigger again and verify counter increments to `testing.2`
- [ ] Trigger with `suffix` input and verify tag format `vX.Y.Z-testing.N+suffix`
- [ ] Publish a testing release draft with a valid commit SHA in the pyCityVisitorParking field and verify the zip contains the correct `manifest.json`
- [ ] Publish a testing release draft without filling in the commit SHA and verify the workflow fails with a clear error

🤖 Generated with [Claude Code](https://claude.ai/claude-code)