### PR TITLE
Add automatic frontend PR labels

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -4,6 +4,16 @@ documentation:
           - "**/*.md"
           - "docs/**"
 
+enhancement:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "custom_components/city_visitor_parking/frontend/**"
+
+frontend:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "custom_components/city_visitor_parking/frontend/**"
+
 tests:
   - changed-files:
       - any-glob-to-any-file:

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -38,6 +38,9 @@
 - name: "javascript"
   color: f1e05a
   description: "Changes related to JavaScript or frontend dependencies."
+- name: "frontend"
+  color: f1e05a
+  description: "Changes related to frontend code or user interface behavior."
 - name: "tests"
   color: 5319e7
   description: "Adds or updates test coverage."


### PR DESCRIPTION
## What changed
Adds automatic PR labeling for frontend changes.

## Highlights
- maps frontend file changes to the existing `enhancement` label
- adds a dedicated `frontend` label
- updates the labeler rules so frontend PRs get labeled automatically

## Notes
- this helps PRs pass the required PR label verification when the changes are frontend-only
- the new `frontend` label also needs to be synced by the existing labels workflow

## Validation
- yamllint
- prettier