### PR TITLE
chore: bump pycityvisitorparking to 0.5.23

### DIFF
--- a/custom_components/city_visitor_parking/manifest.json
+++ b/custom_components/city_visitor_parking/manifest.json
@@ -10,6 +10,6 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/sir-Unknown/ha_City-Visitor-Parking/issues",
   "quality_scale": "platinum",
-  "requirements": ["pycityvisitorparking==0.5.21"],
+  "requirements": ["pycityvisitorparking==0.5.23"],
   "version": "0.1.34-beta.1"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "ha-city-visitor-parking"
 version = "0.0.0"
 requires-python = ">=3.14.2"
-dependencies = ["pycityvisitorparking @ git+https://github.com/sir-Unknown/pyCityVisitorParking.git@9afac8d0501a93057f464a76cf5be810c90d5d3b"]
+dependencies = ["pycityvisitorparking==0.5.23"]
 
 [dependency-groups]
 dev = [
@@ -72,10 +72,7 @@ line-length = 88
 
 [tool.ruff.lint]
 select = ["E", "F", "W", "I", "UP", "B", "D", "C4", "SIM", "DTZ", "RET", "TCH", "PERF", "RUF", "N", "PL", "ANN"]
-ignore = ["D203", "D213"]
-
-[tool.ruff.lint.pydocstyle]
-convention = "google"
+ignore = ["D203", "D204", "D213", "D215", "D400", "D401", "D404", "D406", "D407", "D408", "D409", "D413"]
 
 [tool.ruff.format]
 quote-style = "double"

--- a/uv.lock
+++ b/uv.lock
@@ -909,7 +909,7 @@ test = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "pycityvisitorparking", git = "https://github.com/sir-Unknown/pyCityVisitorParking.git?rev=9afac8d0501a93057f464a76cf5be810c90d5d3b" }]
+requires-dist = [{ name = "pycityvisitorparking", specifier = "==0.5.23" }]
 
 [package.metadata.requires-dev]
 dev = [
@@ -1668,10 +1668,14 @@ wheels = [
 
 [[package]]
 name = "pycityvisitorparking"
-version = "0.5.21.dev6+g9afac8d05"
-source = { git = "https://github.com/sir-Unknown/pyCityVisitorParking.git?rev=9afac8d0501a93057f464a76cf5be810c90d5d3b#9afac8d0501a93057f464a76cf5be810c90d5d3b" }
+version = "0.5.23"
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b4/30/e9e78f7b76cba16f97730fd56d480880025a89d373af1a6fae6d7b784608/pycityvisitorparking-0.5.23.tar.gz", hash = "sha256:be11d2d82d41fb60f8c3e66fb3a40a8ca80120692462a598f5dbe75c7c88da79", size = 69062, upload-time = "2026-04-13T21:57:15.693Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ed/72/9b6db93d4cb63ea4ddb861c3860ad6e2f75bde0c346e9b88c238b138b545/pycityvisitorparking-0.5.23-py3-none-any.whl", hash = "sha256:40703578b40eb7bd1cc242fb373e314a7311ca4035424c5b732026e28ffa17e4", size = 66254, upload-time = "2026-04-13T21:57:13.879Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Switch `pycityvisitorparking` dependency from git-ref pin (`9afac8d`) to released PyPI package `==0.5.23`
- Update `uv.lock` accordingly

## Note

Depends on #123 merging first (the `scripts/run-python-tool.sh` hook venv fix lives there).

## Test plan

- [ ] `uv sync` installs `pycityvisitorparking==0.5.23` from PyPI
- [ ] `PYTHONPATH=. uv run pytest -q tests/components/city_visitor_parking/` passes after #123 is merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)