### PR TITLE
fix: prefer repo .venv over HA core venv in run-python-tool.sh

### DIFF
--- a/scripts/run-python-tool.sh
+++ b/scripts/run-python-tool.sh
@@ -8,15 +8,18 @@ GIT_COMMON_DIR="$(git rev-parse --path-format=absolute --git-common-dir)"
 MAIN_REPO_ROOT="$(dirname "$GIT_COMMON_DIR")"
 HA_CORE_DIR="${HA_CORE_DIR:-$MAIN_REPO_ROOT/../homeassistant-core}"
 HA_VENV_PY="${HA_VENV_PY:-$HA_CORE_DIR/venv/bin/python}"
+REPO_VENV_PY="${REPO_VENV_PY:-$REPO_ROOT/.venv/bin/python}"
 
 select_python_bin() {
-  local candidate
+  local candidate candidate_path
   local bin
 
-  if [[ -x "$HA_VENV_PY" ]] && "$HA_VENV_PY" -c "import sys; sys.exit(0)" >/dev/null 2>&1; then
-    echo "$HA_VENV_PY"
-    return 0
-  fi
+  for candidate_path in "$REPO_VENV_PY" "$HA_VENV_PY"; do
+    if [[ -x "$candidate_path" ]] && "$candidate_path" -c "import sys; sys.exit(0)" >/dev/null 2>&1; then
+      echo "$candidate_path"
+      return 0
+    fi
+  done
 
   for candidate in python python3; do
     if ! command -v "$candidate" >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary

- `run-python-tool.sh` viel terug op de systeem-`python3` als `homeassistant-core` niet als nevenmap aanwezig was, waardoor de dev-venv werd gekozen
- Die dev-venv mist `pytest-homeassistant-custom-component` en de HA-stubs, waardoor pyright en pytest in pre-commit faalden
- Fix: voeg `REPO_VENV_PY` (`.venv` in de repo-root) toe als eerste kandidaat — de eigen venv van de ha-repo heeft alles al

## Test plan

- [ ] Pre-commit hooks draaien door zonder pyright/pytest fouten na deze fix
- [ ] `REPO_VENV_PY` env-var kan nog steeds worden overschreven voor afwijkende setups
- [ ] Fallback naar `HA_VENV_PY` en systeem-python blijft intact

Fixes pyright `reportUntypedBaseClass` / `reportUntypedClassDecorator` en `ModuleNotFoundError: pytest_homeassistant_custom_component` in pre-commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)