### PR TITLE
refactor: replace format_log_metadata with build_log_block for structured logging

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -13,6 +13,9 @@ on:
   workflow_dispatch:
   pull_request:
     branches: ["main"]
+    paths:
+      - "pyproject.toml"
+      - "uv.lock"
 
 concurrency:
   group: dependency-review-${{ github.event.pull_request.number || github.ref }}
@@ -29,21 +32,11 @@ jobs:
       contents: read
       pull-requests: write # Required because `comment-summary-in-pr: on-failure` posts a PR comment.
     steps:
-      - name: "Check for dependency file changes"
-        id: filter
-        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
-        with:
-          filters: |
-            deps:
-              - "pyproject.toml"
-              - "uv.lock"
       - name: "Checkout repository"
-        if: steps.filter.outputs.deps == 'true'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
       - name: "Dependency Review"
-        if: steps.filter.outputs.deps == 'true'
         uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4.9.0
         with:
           base-ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || 'refs/heads/main' }}

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -13,9 +13,6 @@ on:
   workflow_dispatch:
   pull_request:
     branches: ["main"]
-    paths:
-      - "pyproject.toml"
-      - "uv.lock"
 
 concurrency:
   group: dependency-review-${{ github.event.pull_request.number || github.ref }}
@@ -32,11 +29,21 @@ jobs:
       contents: read
       pull-requests: write # Required because `comment-summary-in-pr: on-failure` posts a PR comment.
     steps:
+      - name: "Check for dependency file changes"
+        id: filter
+        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        with:
+          filters: |
+            deps:
+              - "pyproject.toml"
+              - "uv.lock"
       - name: "Checkout repository"
+        if: steps.filter.outputs.deps == 'true'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
       - name: "Dependency Review"
+        if: steps.filter.outputs.deps == 'true'
         uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4.9.0
         with:
           base-ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || 'refs/heads/main' }}

--- a/custom_components/city_visitor_parking/__init__.py
+++ b/custom_components/city_visitor_parking/__init__.py
@@ -47,7 +47,7 @@ from .helpers import normalize_override_windows
 from .models import AutoEndState, OperatingTimeOverrides, ProviderConfig
 from .runtime_data import CityVisitorParkingRuntimeData
 from .services import async_setup_services
-from .version import async_get_versions, format_log_metadata
+from .version import async_get_versions, build_log_block
 from .websocket_api import async_setup_websocket
 
 if TYPE_CHECKING:
@@ -105,8 +105,9 @@ async def async_setup(hass: HomeAssistant, _config: ConfigType) -> bool:
     """Set up the City visitor parking integration."""
     ha_cvp_version, pycvp_version = await async_get_versions(hass)
     _LOGGER.debug(
-        "City Visitor Parking starting %s",
-        format_log_metadata(
+        "%s",
+        build_log_block(
+            "City Visitor Parking starting",
             ha_cvp_version=ha_cvp_version,
             pycvp_version=pycvp_version,
         ),
@@ -324,9 +325,10 @@ async def _async_register_frontend(hass: HomeAssistant, _component: str) -> None
     else:
         ha_cvp_version, pycvp_version = await async_get_versions(hass)
         _LOGGER.warning(
-            "Frontend translations directory is missing: %s %s",
-            translations_path,
-            format_log_metadata(
+            "%s",
+            build_log_block(
+                "frontend translations directory missing",
+                {"path": str(translations_path)},
                 ha_cvp_version=ha_cvp_version,
                 pycvp_version=pycvp_version,
             ),

--- a/custom_components/city_visitor_parking/config_flow.py
+++ b/custom_components/city_visitor_parking/config_flow.py
@@ -40,7 +40,7 @@ from .const import (
 )
 from .helpers import get_attr, normalize_override_windows
 from .models import ProviderConfig
-from .version import async_get_versions, format_log_metadata
+from .version import async_get_versions, build_log_block
 
 SECTION_OPERATING_TIMES: Final[str] = "operating_times"
 
@@ -338,10 +338,10 @@ class CityVisitorParkingConfigFlow(config_entries.ConfigFlow):
             permit = await provider.get_permit()
         except AuthError as err:
             _LOGGER.debug(
-                "Auth error during login for %s: %s %s",
-                self._provider_config.provider_id,
-                err,
-                format_log_metadata(
+                "%s",
+                build_log_block(
+                    "login failed",
+                    {"error-type": type(err).__name__, "error": str(err)},
                     provider=self._provider_config.provider_id,
                     city=self._provider_config.municipality_name,
                     ha_cvp_version=ha_cvp_version,
@@ -353,11 +353,10 @@ class CityVisitorParkingConfigFlow(config_entries.ConfigFlow):
             error_key = "cannot_connect"
         except RateLimitError as err:
             _LOGGER.debug(
-                "Rate limit during login for %s: %s: %s %s",
-                self._provider_config.provider_id,
-                type(err).__name__,
-                err,
-                format_log_metadata(
+                "%s",
+                build_log_block(
+                    "login rate-limited",
+                    {"error-type": type(err).__name__, "error": str(err)},
                     provider=self._provider_config.provider_id,
                     city=self._provider_config.municipality_name,
                     ha_cvp_version=ha_cvp_version,
@@ -367,11 +366,10 @@ class CityVisitorParkingConfigFlow(config_entries.ConfigFlow):
             error_key = "rate_limit"
         except ServiceUnavailableError as err:
             _LOGGER.debug(
-                "Service unavailable during login for %s: %s: %s %s",
-                self._provider_config.provider_id,
-                type(err).__name__,
-                err,
-                format_log_metadata(
+                "%s",
+                build_log_block(
+                    "login service unavailable",
+                    {"error-type": type(err).__name__, "error": str(err)},
                     provider=self._provider_config.provider_id,
                     city=self._provider_config.municipality_name,
                     ha_cvp_version=ha_cvp_version,
@@ -381,11 +379,10 @@ class CityVisitorParkingConfigFlow(config_entries.ConfigFlow):
             error_key = "service_unavailable"
         except PyCityVisitorParkingError as err:
             _LOGGER.debug(
-                "Provider error during login for %s: %s: %s %s",
-                self._provider_config.provider_id,
-                type(err).__name__,
-                err,
-                format_log_metadata(
+                "%s",
+                build_log_block(
+                    "login provider error",
+                    {"error-type": type(err).__name__, "error": str(err)},
                     provider=self._provider_config.provider_id,
                     city=self._provider_config.municipality_name,
                     ha_cvp_version=ha_cvp_version,
@@ -396,11 +393,10 @@ class CityVisitorParkingConfigFlow(config_entries.ConfigFlow):
         # Allowed in config flow
         except Exception as err:  # pylint: disable=broad-exception-caught
             _LOGGER.debug(
-                "Unexpected error during login for %s: %s: %s %s",
-                self._provider_config.provider_id,
-                type(err).__name__,
-                err,
-                format_log_metadata(
+                "%s",
+                build_log_block(
+                    "login unexpected error",
+                    {"error-type": type(err).__name__, "error": str(err)},
                     provider=self._provider_config.provider_id,
                     city=self._provider_config.municipality_name,
                     ha_cvp_version=ha_cvp_version,

--- a/custom_components/city_visitor_parking/coordinator.py
+++ b/custom_components/city_visitor_parking/coordinator.py
@@ -25,7 +25,7 @@ from .models import (
 )
 from .models import Favorite as CoordinatorFavorite
 from .time_windows import windows_for_today
-from .version import async_get_versions, format_log_metadata
+from .version import async_get_versions, build_log_block
 
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Iterable, Mapping
@@ -135,12 +135,15 @@ class CityVisitorParkingCoordinator(DataUpdateCoordinator[CoordinatorData]):
         except AuthError as err:
             self._log_unavailable_once()
             _LOGGER.debug(
-                "Coordinator auth failed for %s (permit %s): %s: %s %s",
-                self._entry_title,
-                self._permit_id,
-                type(err).__name__,
-                err,
-                format_log_metadata(
+                "%s",
+                build_log_block(
+                    "coordinator auth failed",
+                    {
+                        "entry": self._entry_title,
+                        "permit": self._permit_id,
+                        "error-type": type(err).__name__,
+                        "error": str(err),
+                    },
                     provider=self._provider.provider_id,
                     city=getattr(self._provider, "_request_context_name", None)
                     or "unknown",
@@ -152,12 +155,15 @@ class CityVisitorParkingCoordinator(DataUpdateCoordinator[CoordinatorData]):
         except (NetworkError, PyCityVisitorParkingError) as err:
             self._log_unavailable_once()
             _LOGGER.debug(
-                "Coordinator fetch failed for %s (permit %s): %s: %s %s",
-                self._entry_title,
-                self._permit_id,
-                type(err).__name__,
-                err,
-                format_log_metadata(
+                "%s",
+                build_log_block(
+                    "coordinator fetch failed",
+                    {
+                        "entry": self._entry_title,
+                        "permit": self._permit_id,
+                        "error-type": type(err).__name__,
+                        "error": str(err),
+                    },
                     provider=self._provider.provider_id,
                     city=getattr(self._provider, "_request_context_name", None)
                     or "unknown",
@@ -169,12 +175,15 @@ class CityVisitorParkingCoordinator(DataUpdateCoordinator[CoordinatorData]):
         except Exception as err:  # Allowed in background tasks
             self._log_unavailable_once()
             _LOGGER.debug(
-                "Coordinator fetch failed unexpectedly for %s (permit %s): %s: %s %s",
-                self._entry_title,
-                self._permit_id,
-                type(err).__name__,
-                err,
-                format_log_metadata(
+                "%s",
+                build_log_block(
+                    "coordinator fetch failed unexpectedly",
+                    {
+                        "entry": self._entry_title,
+                        "permit": self._permit_id,
+                        "error-type": type(err).__name__,
+                        "error": str(err),
+                    },
                     provider=self._provider.provider_id,
                     city=getattr(self._provider, "_request_context_name", None)
                     or "unknown",

--- a/custom_components/city_visitor_parking/services.py
+++ b/custom_components/city_visitor_parking/services.py
@@ -37,7 +37,7 @@ from .const import (
 )
 from .helpers import normalize_plate
 from .payloads import build_status_payload, normalize_favorites, reservation_payload
-from .version import async_get_versions, format_log_metadata
+from .version import async_get_versions, build_log_block
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
@@ -151,10 +151,10 @@ def _raise_reservation_error(
     """Raise a translated Home Assistant error for reservation failures."""
     detail = _error_detail(err)
     _LOGGER.debug(
-        "Reservation request failed: %s: %s %s",
-        type(err).__name__,
-        err,
-        format_log_metadata(
+        "%s",
+        build_log_block(
+            "reservation request failed",
+            {"error-type": type(err).__name__, "error": str(err)},
             provider=provider,
             city=city,
             ha_cvp_version=ha_cvp_version,
@@ -179,10 +179,10 @@ def _raise_favorite_error(
     """Raise a translated Home Assistant error for favorite failures."""
     if not isinstance(err, PyCityVisitorParkingError):
         _LOGGER.debug(
-            "Favorite request failed: %s: %s %s",
-            type(err).__name__,
-            err,
-            format_log_metadata(
+            "%s",
+            build_log_block(
+                "favorite request failed",
+                {"error-type": type(err).__name__, "error": str(err)},
                 provider=provider,
                 city=city,
                 ha_cvp_version=ha_cvp_version,
@@ -195,10 +195,10 @@ def _raise_favorite_error(
         ) from err
     detail = _error_detail(err)
     _LOGGER.debug(
-        "Favorite request failed: %s: %s %s",
-        type(err).__name__,
-        err,
-        format_log_metadata(
+        "%s",
+        build_log_block(
+            "favorite request failed",
+            {"error-type": type(err).__name__, "error": str(err)},
             provider=provider,
             city=city,
             ha_cvp_version=ha_cvp_version,

--- a/custom_components/city_visitor_parking/version.py
+++ b/custom_components/city_visitor_parking/version.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import importlib.metadata
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from homeassistant.loader import async_get_integration
 
@@ -39,15 +39,25 @@ def get_cached_versions(hass: HomeAssistant) -> tuple[str, str]:
     return hass.data.get(_VERSION_CACHE_KEY, ("unknown", "unknown"))
 
 
-def format_log_metadata(
+def build_log_block(  # noqa: PLR0913
+    label: str,
+    fields: dict[str, Any] | None = None,
     *,
     provider: str = "unknown",
     city: str = "unknown",
     ha_cvp_version: str = "unknown",
     pycvp_version: str = "unknown",
 ) -> str:
-    """Return a consistent logging metadata suffix."""
-    return (
-        f"(provider={provider}, city={city}, "
-        f"hacvp={ha_cvp_version}, pycvp={pycvp_version})"
+    """Return a labelled multi-line key=value block with provider metadata."""
+    all_fields = {k: v for k, v in (fields or {}).items() if v is not None}
+    all_fields.update(
+        {
+            "provider": provider,
+            "city": city,
+            "hacvp": ha_cvp_version,
+            "pycvp": pycvp_version,
+        }
     )
+    width = max(len(k) for k in all_fields)
+    lines = [label, *[f"  {k:<{width}} = {v}" for k, v in all_fields.items()]]
+    return "\n".join(lines)

--- a/tests/components/city_visitor_parking/test_config_flow.py
+++ b/tests/components/city_visitor_parking/test_config_flow.py
@@ -218,7 +218,8 @@ async def test_config_flow_invalid_auth(
 
     assert result["type"] == "form"
     assert result["errors"]["base"] == "invalid_auth"
-    assert "hacvp=1.2.3, pycvp=4.5.6" in caplog.text
+    assert "hacvp" in caplog.text
+    assert "1.2.3" in caplog.text
 
 
 async def test_config_flow_cannot_connect(
@@ -465,7 +466,8 @@ async def test_validate_credentials_unexpected_error(
 
     assert permit_id is None
     assert errors["base"] == "unknown"
-    assert "hacvp=1.2.3, pycvp=4.5.6" in caplog.text
+    assert "hacvp" in caplog.text
+    assert "1.2.3" in caplog.text
 
 
 async def test_validate_credentials_no_permits(
@@ -551,7 +553,7 @@ def _extract_option_values(selector: dict[str, object] | _SelectorConfig) -> lis
         if isinstance(option, dict):
             values.append(option["value"])
         else:
-            values.append(option.value)
+            values.append(option.value)  # type: ignore[attr-defined]
     return values
 
 
@@ -567,7 +569,7 @@ def _extract_option_labels(selector: dict[str, object] | _SelectorConfig) -> lis
         if isinstance(option, dict):
             labels.append(option["label"])
         else:
-            labels.append(option.label)
+            labels.append(option.label)  # type: ignore[attr-defined]
     return labels
 
 

--- a/tests/components/city_visitor_parking/test_coordinator.py
+++ b/tests/components/city_visitor_parking/test_coordinator.py
@@ -122,7 +122,8 @@ async def test_auth_failure_triggers_reauth(
     ):
         await coordinator.async_refresh()
     assert isinstance(coordinator.last_exception, ConfigEntryAuthFailed)
-    assert "hacvp=1.2.3, pycvp=4.5.6" in caplog.text
+    assert "hacvp" in caplog.text
+    assert "1.2.3" in caplog.text
 
 
 async def test_network_failure_raises_updatefailed(
@@ -155,7 +156,8 @@ async def test_network_failure_raises_updatefailed(
     ):
         await coordinator.async_refresh()
     assert isinstance(coordinator.last_exception, UpdateFailed)
-    assert "hacvp=1.2.3, pycvp=4.5.6" in caplog.text
+    assert "hacvp" in caplog.text
+    assert "1.2.3" in caplog.text
 
 
 async def test_unexpected_failure_raises_updatefailed(hass: HomeAssistant) -> None:

--- a/tests/components/city_visitor_parking/test_init.py
+++ b/tests/components/city_visitor_parking/test_init.py
@@ -208,7 +208,8 @@ async def test_register_frontend_assets_missing_translations(
 
     hass.http.async_register_static_paths.assert_awaited_once()
     assert hass.data[DOMAIN]["frontend_registered"] is True
-    assert "hacvp=1.2.3, pycvp=4.5.6" in caplog.text
+    assert "hacvp" in caplog.text
+    assert "1.2.3" in caplog.text
 
 
 async def test_register_lovelace_resources_non_storage(

--- a/tests/components/city_visitor_parking/test_services.py
+++ b/tests/components/city_visitor_parking/test_services.py
@@ -413,7 +413,8 @@ async def test_service_start_reservation_error(
             },
             blocking=True,
         )
-    assert "hacvp=1.2.3, pycvp=4.5.6" in caplog.text
+    assert "hacvp" in caplog.text
+    assert "1.2.3" in caplog.text
 
 
 async def test_update_reservation_requires_full_details(
@@ -603,7 +604,8 @@ async def test_service_add_favorite_error(
             },
             blocking=True,
         )
-    assert "hacvp=1.2.3, pycvp=4.5.6" in caplog.text
+    assert "hacvp" in caplog.text
+    assert "1.2.3" in caplog.text
 
 
 async def test_service_update_favorite_requires_changes(


### PR DESCRIPTION
## Summary
- Replaces `format_log_metadata` with `build_log_block` in `version.py`
- Updates all call sites in `__init__.py`, `config_flow.py`, `coordinator.py`, `services.py`
- Updates tests accordingly

## Why
`build_log_block` produces readable multi-line key=value output per log entry, with a label on the first line and aligned fields below. Each call site can add context-specific fields (e.g. `path`, `entry`, `permit`, `error-type`) on top of the standard provider metadata.

## Test plan
- [ ] CI passes (mypy, pyright, pytest, ruff)

🤖 Generated with [Claude Code](https://claude.com/claude-code)