### PR TITLE
feat(card): add default_license_plate option

### DIFF
--- a/custom_components/city_visitor_parking/frontend/dist/city-visitor-parking-card.js
+++ b/custom_components/city_visitor_parking/frontend/dist/city-visitor-parking-card.js
@@ -1218,7 +1218,8 @@ var buildCardEditorSchema = (cardTypeOptions, displayOptionsExpanded) => [
       },
       { name: "show_favorites", selector: { boolean: {} }, default: true },
       { name: "show_start_time", selector: { boolean: {} }, default: true },
-      { name: "show_end_time", selector: { boolean: {} }, default: true }
+      { name: "show_end_time", selector: { boolean: {} }, default: true },
+      { name: "default_license_plate", selector: { text: {} }, required: false }
     ]
   }
 ];
@@ -1233,7 +1234,7 @@ var CityVisitorParkingCardEditor = class extends BaseCardEditor {
     );
     const cardTypeOptions = buildCardTypeOptions(localizeTarget, "editor");
     const displayOptionsExpanded = Boolean(
-      this._config?.config_entry_id || this._config?.show_favorites === false || this._config?.show_start_time === false || this._config?.show_end_time === false
+      this._config?.config_entry_id || this._config?.show_favorites === false || this._config?.show_start_time === false || this._config?.show_end_time === false || this._config?.default_license_plate
     );
     return b2`
       <ha-form
@@ -1443,6 +1444,9 @@ var getActiveCardConfigForm = createConfigFormGetter(
         show_end_time: config.show_end_time !== false,
         ...config
       };
+      if (this._config.default_license_plate && !this._formValues["licensePlate"]) {
+        this._setInputValue("licensePlate", this._config.default_license_plate);
+      }
       if (priorShowFavorites && !this._config.show_favorites) {
         this._resetFavoritesState();
         this._setInputValue("favorite", "");
@@ -1977,6 +1981,9 @@ var getActiveCardConfigForm = createConfigFormGetter(
       const hadValues = Object.keys(this._formValues).length > 0;
       const hadAddFavoriteChecked = this._addFavoriteChecked;
       this._formValues = {};
+      if (this._config?.default_license_plate) {
+        this._formValues["licensePlate"] = this._config.default_license_plate;
+      }
       clearFavoriteTransientState(this);
       if (hadValues || hadAddFavoriteChecked) this._requestRender();
     }

--- a/custom_components/city_visitor_parking/frontend/dist/translations/en.json
+++ b/custom_components/city_visitor_parking/frontend/dist/translations/en.json
@@ -72,5 +72,7 @@
   "message.reservation_update_failed": "We could not update your reservation.",
   "message.reservation_ended": "Your reservation was ended.",
   "message.reservation_end_failed": "We could not end your reservation.",
-  "placeholder.license_plate": "AA-123-B"
+  "placeholder.license_plate": "AA-123-B",
+  "editor.field.default_license_plate": "Default license plate",
+  "editor.description.default_license_plate": "Optional. Pre-fill the license plate field with this value when the form is empty or reset."
 }

--- a/custom_components/city_visitor_parking/frontend/dist/translations/nl.json
+++ b/custom_components/city_visitor_parking/frontend/dist/translations/nl.json
@@ -41,7 +41,7 @@
   "action.remove_favorite": "Favoriet verwijderen",
   "action.start_reservation": "Reservering starten",
   "button.update_reservation": "Reservering bijwerken",
-  "button.end_reservation": "Reservering be\u00ebindigen",
+  "button.end_reservation": "Reservering beëindigen",
   "section.active_reservations": "Actieve reserveringen",
   "label.parking_status": "Parkeerstatus",
   "label.window": "Tijdvenster",
@@ -70,7 +70,9 @@
   "message.reservation_start_failed": "We kunnen je reservering niet starten.",
   "message.reservation_updated": "Je reservering is bijgewerkt.",
   "message.reservation_update_failed": "We kunnen je reservering niet bijwerken.",
-  "message.reservation_ended": "Je reservering is be\u00ebindigd.",
-  "message.reservation_end_failed": "We kunnen je reservering niet be\u00ebindigen.",
-  "placeholder.license_plate": "AA-123-B"
+  "message.reservation_ended": "Je reservering is beëindigd.",
+  "message.reservation_end_failed": "We kunnen je reservering niet beëindigen.",
+  "placeholder.license_plate": "AA-123-B",
+  "editor.field.default_license_plate": "Standaard kenteken",
+  "editor.description.default_license_plate": "Optioneel. Vul het kentekenveld voorin met deze waarde als het formulier leeg of gereset is."
 }

--- a/custom_components/city_visitor_parking/frontend/src/index.ts
+++ b/custom_components/city_visitor_parking/frontend/src/index.ts
@@ -966,6 +966,7 @@ type ParkingCardEditorConfig = {
   show_start_time?: boolean;
   show_end_time?: boolean;
   config_entry_id?: string;
+  default_license_plate?: string;
 };
 
 type CardEditorFormSchema = ReadonlyArray<Record<string, unknown>>;
@@ -996,6 +997,7 @@ const buildCardEditorSchema = (
       { name: "show_favorites", selector: { boolean: {} }, default: true },
       { name: "show_start_time", selector: { boolean: {} }, default: true },
       { name: "show_end_time", selector: { boolean: {} }, default: true },
+      { name: "default_license_plate", selector: { text: {} }, required: false },
     ],
   },
 ];
@@ -1014,7 +1016,8 @@ class CityVisitorParkingCardEditor extends BaseCardEditor<ParkingCardEditorConfi
       this._config?.config_entry_id ||
       this._config?.show_favorites === false ||
       this._config?.show_start_time === false ||
-      this._config?.show_end_time === false,
+      this._config?.show_end_time === false ||
+      this._config?.default_license_plate,
     );
     return html`
       <ha-form
@@ -1177,6 +1180,7 @@ const getActiveCardConfigForm = createConfigFormGetter(
     show_end_time?: boolean;
     config_entry_id?: string;
     device_id?: string;
+    default_license_plate?: string;
   };
   type CheckedElement = HTMLElement & { checked: boolean; disabled?: boolean };
   type FavoriteActionState = {
@@ -1325,6 +1329,9 @@ const getActiveCardConfigForm = createConfigFormGetter(
         show_end_time: config.show_end_time !== false,
         ...config,
       };
+      if (this._config.default_license_plate && !this._formValues["licensePlate"]) {
+        this._setInputValue("licensePlate", this._config.default_license_plate);
+      }
       if (priorShowFavorites && !this._config.show_favorites) {
         this._resetFavoritesState();
         this._setInputValue("favorite", "");
@@ -1951,6 +1958,9 @@ const getActiveCardConfigForm = createConfigFormGetter(
       const hadValues = Object.keys(this._formValues).length > 0;
       const hadAddFavoriteChecked = this._addFavoriteChecked;
       this._formValues = {};
+      if (this._config?.default_license_plate) {
+        this._formValues["licensePlate"] = this._config.default_license_plate;
+      }
       clearFavoriteTransientState(this);
       if (hadValues || hadAddFavoriteChecked) this._requestRender();
     }

--- a/custom_components/city_visitor_parking/frontend/src/translations/en.json
+++ b/custom_components/city_visitor_parking/frontend/src/translations/en.json
@@ -72,5 +72,7 @@
   "message.reservation_update_failed": "We could not update your reservation.",
   "message.reservation_ended": "Your reservation was ended.",
   "message.reservation_end_failed": "We could not end your reservation.",
-  "placeholder.license_plate": "AA-123-B"
+  "placeholder.license_plate": "AA-123-B",
+  "editor.field.default_license_plate": "Default license plate",
+  "editor.description.default_license_plate": "Optional. Pre-fill the license plate field with this value when the form is empty or reset."
 }

--- a/custom_components/city_visitor_parking/frontend/src/translations/nl.json
+++ b/custom_components/city_visitor_parking/frontend/src/translations/nl.json
@@ -41,7 +41,7 @@
   "action.remove_favorite": "Favoriet verwijderen",
   "action.start_reservation": "Reservering starten",
   "button.update_reservation": "Reservering bijwerken",
-  "button.end_reservation": "Reservering be\u00ebindigen",
+  "button.end_reservation": "Reservering beëindigen",
   "section.active_reservations": "Actieve reserveringen",
   "label.parking_status": "Parkeerstatus",
   "label.window": "Tijdvenster",
@@ -70,7 +70,9 @@
   "message.reservation_start_failed": "We kunnen je reservering niet starten.",
   "message.reservation_updated": "Je reservering is bijgewerkt.",
   "message.reservation_update_failed": "We kunnen je reservering niet bijwerken.",
-  "message.reservation_ended": "Je reservering is be\u00ebindigd.",
-  "message.reservation_end_failed": "We kunnen je reservering niet be\u00ebindigen.",
-  "placeholder.license_plate": "AA-123-B"
+  "message.reservation_ended": "Je reservering is beëindigd.",
+  "message.reservation_end_failed": "We kunnen je reservering niet beëindigen.",
+  "placeholder.license_plate": "AA-123-B",
+  "editor.field.default_license_plate": "Standaard kenteken",
+  "editor.description.default_license_plate": "Optioneel. Vul het kentekenveld voorin met deze waarde als het formulier leeg of gereset is."
 }


### PR DESCRIPTION
Supersedes #96 with a clean branch history.

Adds a `default_license_plate` card option that pre-fills the license plate field when the form is empty or reset after a completed reservation.

Config:
```yaml
type: custom:city-visitor-parking-card
default_license_plate: AB-123-C
```

- Pre-fills on card load if LP field is empty
- Re-applied after a reservation completes and the form resets
- Configurable via card editor (in display options)
- EN + NL translations included