### PR TITLE
feat(card): add show_name toggle to card editor

### DIFF
--- a/custom_components/city_visitor_parking/frontend/dist/city-visitor-parking-card.js
+++ b/custom_components/city_visitor_parking/frontend/dist/city-visitor-parking-card.js
@@ -882,6 +882,18 @@ var renderCardHeader = (title, icon) => {
   `;
 };
 var renderPermitSelect = (params) => {
+  if (params.preview) {
+    return b2`
+      <div class="row">
+        <ha-input
+          appearance="material"
+          .label=${params.label}
+          .value=${params.value}
+          ?disabled=${true}
+        ></ha-input>
+      </div>
+    `;
+  }
   return b2`
     <div class="row">
       <ha-selector
@@ -902,7 +914,7 @@ var renderPermitSelect = (params) => {
   `;
 };
 var renderFavoriteSelect = (params) => {
-  if (!params.showFavorites) return A;
+  if (!params.showName) return A;
   const selectOptions = [];
   const favoriteItems = [];
   const seenValues = /* @__PURE__ */ new Set();
@@ -923,6 +935,30 @@ var renderFavoriteSelect = (params) => {
   );
   selectOptions.push(...favoriteItems);
   const inputValue = params.favoriteValue;
+  if (params.preview) {
+    return b2`
+      <div class="row">
+        <ha-input
+          appearance="material"
+          .label=${params.localize("field.name")}
+          .value=${inputValue}
+          ?disabled=${true}
+        ></ha-input>
+      </div>
+    `;
+  }
+  if (!params.showFavorites) {
+    return b2`
+      <div class="row">
+        <ha-input
+          id="favorite"
+          appearance="material"
+          .label=${params.localize("field.name")}
+          .value=${inputValue}
+        ></ha-input>
+      </div>
+    `;
+  }
   const selectContent = b2`
     <ha-selector
       id="favorite"
@@ -1216,10 +1252,15 @@ var buildCardEditorSchema = (cardTypeOptions, displayOptionsExpanded) => [
         selector: { config_entry: { integration: DOMAIN } },
         required: false
       },
+      { name: "show_name", selector: { boolean: {} }, default: true },
       { name: "show_favorites", selector: { boolean: {} }, default: true },
       { name: "show_start_time", selector: { boolean: {} }, default: true },
       { name: "show_end_time", selector: { boolean: {} }, default: true },
-      { name: "default_license_plate", selector: { text: {} }, required: false }
+      {
+        name: "default_license_plate",
+        selector: { text: {} },
+        required: false
+      }
     ]
   }
 ];
@@ -1234,7 +1275,7 @@ var CityVisitorParkingCardEditor = class extends BaseCardEditor {
     );
     const cardTypeOptions = buildCardTypeOptions(localizeTarget, "editor");
     const displayOptionsExpanded = Boolean(
-      this._config?.config_entry_id || this._config?.show_favorites === false || this._config?.show_start_time === false || this._config?.show_end_time === false || this._config?.default_license_plate
+      this._config?.config_entry_id || this._config?.show_name === false || this._config?.show_favorites === false || this._config?.show_start_time === false || this._config?.show_end_time === false || this._config?.default_license_plate
     );
     return b2`
       <ha-form
@@ -1351,6 +1392,7 @@ var getActiveCardConfigForm = createConfigFormGetter(
   const STATUS_REFRESH_MS = 6e4;
   const INPUT_VALUE_IDS = /* @__PURE__ */ new Set([
     "licensePlate",
+    "favorite",
     "startDateTime",
     "endDateTime"
   ]);
@@ -1422,6 +1464,7 @@ var getActiveCardConfigForm = createConfigFormGetter(
     static getStubConfig() {
       return {
         type: `custom:${CARD_TYPE}`,
+        show_name: true,
         show_favorites: true,
         show_start_time: true,
         show_end_time: true
@@ -1437,8 +1480,10 @@ var getActiveCardConfigForm = createConfigFormGetter(
         );
       }
       const priorEntryId = this._getActiveEntryId();
+      const priorShowName = this._config?.show_name ?? true;
       const priorShowFavorites = this._config?.show_favorites ?? true;
       this._config = {
+        show_name: config.show_name !== false,
         show_favorites: config.show_favorites !== false,
         show_start_time: config.show_start_time !== false,
         show_end_time: config.show_end_time !== false,
@@ -1446,6 +1491,9 @@ var getActiveCardConfigForm = createConfigFormGetter(
       };
       if (this._config.default_license_plate && !this._formValues["licensePlate"]) {
         this._setInputValue("licensePlate", this._config.default_license_plate);
+      }
+      if (priorShowName && !this._config.show_name) {
+        this._setInputValue("favorite", "");
       }
       if (priorShowFavorites && !this._config.show_favorites) {
         this._resetFavoritesState();
@@ -1493,8 +1541,7 @@ var getActiveCardConfigForm = createConfigFormGetter(
     getGridOptions() {
       return {
         columns: 12,
-        rows: 4,
-        min_columns: 4,
+        min_columns: 6,
         min_rows: 2
       };
     }
@@ -1571,7 +1618,8 @@ var getActiveCardConfigForm = createConfigFormGetter(
       return loadPromise;
     }
     async _maybeLoadFavorites() {
-      if (!this._hass || !this._config?.show_favorites) return;
+      if (!this._hass || !this._config?.show_favorites || !this._config?.show_name)
+        return;
       if (!isHassRunning(this._hass)) return;
       const entryId = this._getActiveEntryId();
       if (!entryId) return;
@@ -1665,7 +1713,7 @@ var getActiveCardConfigForm = createConfigFormGetter(
       return loadPromise;
     }
     _getFavoriteActionState() {
-      if (!this._config?.show_favorites) {
+      if (!this._config?.show_favorites || !this._config?.show_name) {
         return {
           showAddFavorite: false,
           showRemoveFavorite: false,
@@ -1705,6 +1753,7 @@ var getActiveCardConfigForm = createConfigFormGetter(
       const priorFavorite = this._getInputValue("favorite");
       const title = this._config.title || "";
       const icon = this._config.icon;
+      const showName = this._config.show_name ?? true;
       const showFavorites = this._config.show_favorites ?? true;
       const showStart = this._config.show_start_time ?? true;
       const showEnd = this._config.show_end_time ?? true;
@@ -1739,15 +1788,18 @@ var getActiveCardConfigForm = createConfigFormGetter(
         label: localizeFn("field.permit"),
         value: permitSelectValue,
         disabled: permitSelectDisabled,
+        preview: controlsDisabled,
         onSelected: this._onPermitSelectChange
       }) : A}
             ${renderFavoriteSelect({
+        showName,
         showFavorites,
         favoriteValue,
         favoriteSelectDisabled,
         hass: this._hass,
         favoritesOptions,
         favoritesError: this._favoritesError,
+        preview: controlsDisabled,
         localize: localizeFn,
         onSelected: this._onFavoriteSelectChange,
         wrapSelect: (content) => i6(activeEntryId ?? "", content)
@@ -1760,6 +1812,7 @@ var getActiveCardConfigForm = createConfigFormGetter(
                 .label=${localizeFn("field.license_plate")}
                 placeholder=${this._licensePlateFocused ? localizeFn("placeholder.license_plate") : ""}
                 .value=${priorLicense}
+                ?disabled=${controlsDisabled}
                 @focusin=${this._onLicensePlateFocusIn}
                 @focusout=${this._onLicensePlateFocusOut}
               ></ha-input>
@@ -1799,7 +1852,7 @@ var getActiveCardConfigForm = createConfigFormGetter(
                   </div>
                 ` : A}
             ${renderFavoriteActionRow({
-        showFavorites,
+        showFavorites: showFavorites && showName,
         showAddFavorite,
         showRemoveFavorite,
         selectedFavoriteId: removeFavorite?.id || removeFavorite?.license_plate || "",
@@ -1827,7 +1880,7 @@ var getActiveCardConfigForm = createConfigFormGetter(
       }
     }
     _scheduleFavoriteActionsUpdate() {
-      if (!this._config?.show_favorites) return;
+      if (!this._config?.show_favorites || !this._config?.show_name) return;
       const license = this._getInputValue("licensePlate").trim();
       const name = this._getInputValue("favorite").trim();
       const matchingFavorite = this._findFavorite(license, name);
@@ -1895,7 +1948,8 @@ var getActiveCardConfigForm = createConfigFormGetter(
       this._handlePermitChange(nextValue);
     }
     _handleFavoriteSelectChange(event) {
-      if (!this._config?.show_favorites || this._isInEditor()) return;
+      if (!this._config?.show_favorites || !this._config?.show_name || this._isInEditor())
+        return;
       const detail = event.detail;
       const select = event.currentTarget;
       const path = event.composedPath();
@@ -2494,9 +2548,8 @@ var getActiveCardConfigForm = createConfigFormGetter(
     getGridOptions() {
       return {
         columns: 12,
-        rows: 4,
-        min_columns: 4,
-        min_rows: 1
+        min_columns: 6,
+        min_rows: 4
       };
     }
     async _maybeLoadActiveReservations(force = false) {

--- a/custom_components/city_visitor_parking/frontend/dist/translations/en.json
+++ b/custom_components/city_visitor_parking/frontend/dist/translations/en.json
@@ -8,6 +8,8 @@
   "editor.field.icon": "Icon",
   "editor.field.type": "Card type",
   "editor.field.display_options": "Display options",
+  "editor.field.default_license_plate": "Default license plate",
+  "editor.field.show_name": "Show name",
   "editor.field.show_favorites": "Show favorites",
   "editor.field.show_start_time": "Show start time",
   "editor.field.show_end_time": "Show end time",
@@ -16,6 +18,8 @@
   "editor.description.config_entry": "Optional. Choose a permit to link the card to. Leave empty to show a selector.",
   "editor.description.title": "Optional custom title shown at the top of the card.",
   "editor.description.icon": "Optional icon shown next to the title.",
+  "editor.description.default_license_plate": "Optional. Pre-fill the license plate field with this value when the form is empty or reset.",
+  "editor.description.show_name": "Show the name field in the reservation form.",
   "editor.description.show_favorites": "Show the favorites picker in the reservation form.",
   "editor.description.show_start_time": "Allow selecting a start time in the reservation form.",
   "editor.description.show_end_time": "Allow selecting an end time in the reservation form.",
@@ -72,7 +76,5 @@
   "message.reservation_update_failed": "We could not update your reservation.",
   "message.reservation_ended": "Your reservation was ended.",
   "message.reservation_end_failed": "We could not end your reservation.",
-  "placeholder.license_plate": "AA-123-B",
-  "editor.field.default_license_plate": "Default license plate",
-  "editor.description.default_license_plate": "Optional. Pre-fill the license plate field with this value when the form is empty or reset."
+  "placeholder.license_plate": "AA-123-B"
 }

--- a/custom_components/city_visitor_parking/frontend/dist/translations/nl.json
+++ b/custom_components/city_visitor_parking/frontend/dist/translations/nl.json
@@ -8,6 +8,8 @@
   "editor.field.icon": "Pictogram",
   "editor.field.type": "Kaarttype",
   "editor.field.display_options": "Weergaveopties",
+  "editor.field.default_license_plate": "Standaard kenteken",
+  "editor.field.show_name": "Toon naam",
   "editor.field.show_favorites": "Toon favorieten",
   "editor.field.show_start_time": "Toon starttijd",
   "editor.field.show_end_time": "Toon eindtijd",
@@ -16,6 +18,8 @@
   "editor.description.config_entry": "Optioneel. Kies een vergunning om de kaart te koppelen. Laat leeg om een keuzeveld te tonen.",
   "editor.description.title": "Optioneel. Aangepaste titel bovenaan de kaart.",
   "editor.description.icon": "Optioneel. Pictogram naast de titel.",
+  "editor.description.default_license_plate": "Optioneel. Vul het kentekenveld voorin met deze waarde als het formulier leeg of gereset is.",
+  "editor.description.show_name": "Toon het naamveld in het reserveringsformulier.",
   "editor.description.show_favorites": "Toon de favorietenkeuze in het reserveringsformulier.",
   "editor.description.show_start_time": "Sta het kiezen van een starttijd toe in het reserveringsformulier.",
   "editor.description.show_end_time": "Sta het kiezen van een eindtijd toe in het reserveringsformulier.",
@@ -72,7 +76,5 @@
   "message.reservation_update_failed": "We kunnen je reservering niet bijwerken.",
   "message.reservation_ended": "Je reservering is beëindigd.",
   "message.reservation_end_failed": "We kunnen je reservering niet beëindigen.",
-  "placeholder.license_plate": "AA-123-B",
-  "editor.field.default_license_plate": "Standaard kenteken",
-  "editor.description.default_license_plate": "Optioneel. Vul het kentekenveld voorin met deze waarde als het formulier leeg of gereset is."
+  "placeholder.license_plate": "AA-123-B"
 }

--- a/custom_components/city_visitor_parking/frontend/src/index.ts
+++ b/custom_components/city_visitor_parking/frontend/src/index.ts
@@ -505,8 +505,21 @@ const renderPermitSelect = (params: {
   label: string;
   value: string;
   disabled: boolean;
+  preview?: boolean;
   onSelected: (event: Event) => void;
 }): TemplateResult => {
+  if (params.preview) {
+    return html`
+      <div class="row">
+        <ha-input
+          appearance="material"
+          .label=${params.label}
+          .value=${params.value}
+          ?disabled=${true}
+        ></ha-input>
+      </div>
+    `;
+  }
   return html`
     <div class="row">
       <ha-selector
@@ -528,17 +541,19 @@ const renderPermitSelect = (params: {
 };
 
 const renderFavoriteSelect = (params: {
+  showName: boolean;
   showFavorites: boolean;
   favoriteValue: string;
   favoriteSelectDisabled: boolean;
   hass: HomeAssistant | null | undefined;
   favoritesOptions: FavoriteOption[];
   favoritesError: string | null;
+  preview?: boolean;
   wrapSelect?: (content: TemplateResult) => unknown;
   localize: (key: string, ...args: Array<string | number>) => string;
   onSelected: (event: Event) => void;
 }): TemplateResult | typeof nothing => {
-  if (!params.showFavorites) return nothing;
+  if (!params.showName) return nothing;
 
   type FavoriteSelectOption = {
     value: string;
@@ -570,6 +585,32 @@ const renderFavoriteSelect = (params: {
   );
   selectOptions.push(...favoriteItems);
   const inputValue = params.favoriteValue;
+
+  if (params.preview) {
+    return html`
+      <div class="row">
+        <ha-input
+          appearance="material"
+          .label=${params.localize("field.name")}
+          .value=${inputValue}
+          ?disabled=${true}
+        ></ha-input>
+      </div>
+    `;
+  }
+
+  if (!params.showFavorites) {
+    return html`
+      <div class="row">
+        <ha-input
+          id="favorite"
+          appearance="material"
+          .label=${params.localize("field.name")}
+          .value=${inputValue}
+        ></ha-input>
+      </div>
+    `;
+  }
 
   const selectContent = html`
     <ha-selector
@@ -962,11 +1003,12 @@ type ParkingCardEditorConfig = {
   type: string;
   title?: string;
   icon?: string;
+  show_name?: boolean;
   show_favorites?: boolean;
   show_start_time?: boolean;
   show_end_time?: boolean;
-  config_entry_id?: string;
   default_license_plate?: string;
+  config_entry_id?: string;
 };
 
 type CardEditorFormSchema = ReadonlyArray<Record<string, unknown>>;
@@ -994,10 +1036,15 @@ const buildCardEditorSchema = (
         selector: { config_entry: { integration: DOMAIN } },
         required: false,
       },
+      { name: "show_name", selector: { boolean: {} }, default: true },
       { name: "show_favorites", selector: { boolean: {} }, default: true },
       { name: "show_start_time", selector: { boolean: {} }, default: true },
       { name: "show_end_time", selector: { boolean: {} }, default: true },
-      { name: "default_license_plate", selector: { text: {} }, required: false },
+      {
+        name: "default_license_plate",
+        selector: { text: {} },
+        required: false,
+      },
     ],
   },
 ];
@@ -1014,6 +1061,7 @@ class CityVisitorParkingCardEditor extends BaseCardEditor<ParkingCardEditorConfi
     const cardTypeOptions = buildCardTypeOptions(localizeTarget, "editor");
     const displayOptionsExpanded = Boolean(
       this._config?.config_entry_id ||
+      this._config?.show_name === false ||
       this._config?.show_favorites === false ||
       this._config?.show_start_time === false ||
       this._config?.show_end_time === false ||
@@ -1175,12 +1223,13 @@ const getActiveCardConfigForm = createConfigFormGetter(
     type: string;
     title?: string;
     icon?: string;
+    show_name?: boolean;
     show_favorites?: boolean;
     show_start_time?: boolean;
     show_end_time?: boolean;
+    default_license_plate?: string;
     config_entry_id?: string;
     device_id?: string;
-    default_license_plate?: string;
   };
   type CheckedElement = HTMLElement & { checked: boolean; disabled?: boolean };
   type FavoriteActionState = {
@@ -1192,6 +1241,7 @@ const getActiveCardConfigForm = createConfigFormGetter(
 
   const INPUT_VALUE_IDS = new Set([
     "licensePlate",
+    "favorite",
     "startDateTime",
     "endDateTime",
   ]);
@@ -1306,6 +1356,7 @@ const getActiveCardConfigForm = createConfigFormGetter(
     static getStubConfig(): CardConfig {
       return {
         type: `custom:${CARD_TYPE}`,
+        show_name: true,
         show_favorites: true,
         show_start_time: true,
         show_end_time: true,
@@ -1322,15 +1373,23 @@ const getActiveCardConfigForm = createConfigFormGetter(
         );
       }
       const priorEntryId = this._getActiveEntryId();
+      const priorShowName = this._config?.show_name ?? true;
       const priorShowFavorites = this._config?.show_favorites ?? true;
       this._config = {
+        show_name: config.show_name !== false,
         show_favorites: config.show_favorites !== false,
         show_start_time: config.show_start_time !== false,
         show_end_time: config.show_end_time !== false,
         ...config,
       };
-      if (this._config.default_license_plate && !this._formValues["licensePlate"]) {
+      if (
+        this._config.default_license_plate &&
+        !this._formValues["licensePlate"]
+      ) {
         this._setInputValue("licensePlate", this._config.default_license_plate);
+      }
+      if (priorShowName && !this._config.show_name) {
+        this._setInputValue("favorite", "");
       }
       if (priorShowFavorites && !this._config.show_favorites) {
         this._resetFavoritesState();
@@ -1385,8 +1444,7 @@ const getActiveCardConfigForm = createConfigFormGetter(
     getGridOptions(): Record<string, number> {
       return {
         columns: 12,
-        rows: 4,
-        min_columns: 4,
+        min_columns: 6,
         min_rows: 2,
       };
     }
@@ -1475,7 +1533,12 @@ const getActiveCardConfigForm = createConfigFormGetter(
     }
 
     async _maybeLoadFavorites(): Promise<void> {
-      if (!this._hass || !this._config?.show_favorites) return;
+      if (
+        !this._hass ||
+        !this._config?.show_favorites ||
+        !this._config?.show_name
+      )
+        return;
       if (!isHassRunning(this._hass)) return;
       const entryId = this._getActiveEntryId();
       if (!entryId) return;
@@ -1571,7 +1634,7 @@ const getActiveCardConfigForm = createConfigFormGetter(
     }
 
     _getFavoriteActionState(): FavoriteActionState {
-      if (!this._config?.show_favorites) {
+      if (!this._config?.show_favorites || !this._config?.show_name) {
         return {
           showAddFavorite: false,
           showRemoveFavorite: false,
@@ -1629,6 +1692,7 @@ const getActiveCardConfigForm = createConfigFormGetter(
 
       const title = this._config.title || "";
       const icon = this._config.icon;
+      const showName = this._config.show_name ?? true;
       const showFavorites = this._config.show_favorites ?? true;
       const showStart = this._config.show_start_time ?? true;
       const showEnd = this._config.show_end_time ?? true;
@@ -1674,16 +1738,19 @@ const getActiveCardConfigForm = createConfigFormGetter(
                   label: localizeFn("field.permit"),
                   value: permitSelectValue,
                   disabled: permitSelectDisabled,
+                  preview: controlsDisabled,
                   onSelected: this._onPermitSelectChange,
                 })
               : nothing}
             ${renderFavoriteSelect({
+              showName,
               showFavorites,
               favoriteValue,
               favoriteSelectDisabled,
               hass: this._hass,
               favoritesOptions,
               favoritesError: this._favoritesError,
+              preview: controlsDisabled,
               localize: localizeFn,
               onSelected: this._onFavoriteSelectChange,
               wrapSelect: (content) => keyed(activeEntryId ?? "", content),
@@ -1698,6 +1765,7 @@ const getActiveCardConfigForm = createConfigFormGetter(
                   ? localizeFn("placeholder.license_plate")
                   : ""}
                 .value=${priorLicense}
+                ?disabled=${controlsDisabled}
                 @focusin=${this._onLicensePlateFocusIn}
                 @focusout=${this._onLicensePlateFocusOut}
               ></ha-input>
@@ -1743,7 +1811,7 @@ const getActiveCardConfigForm = createConfigFormGetter(
                 `
               : nothing}
             ${renderFavoriteActionRow({
-              showFavorites,
+              showFavorites: showFavorites && showName,
               showAddFavorite,
               showRemoveFavorite,
               selectedFavoriteId:
@@ -1774,7 +1842,7 @@ const getActiveCardConfigForm = createConfigFormGetter(
     }
 
     _scheduleFavoriteActionsUpdate(): void {
-      if (!this._config?.show_favorites) return;
+      if (!this._config?.show_favorites || !this._config?.show_name) return;
       const license = this._getInputValue("licensePlate").trim();
       const name = this._getInputValue("favorite").trim();
       const matchingFavorite = this._findFavorite(license, name);
@@ -1858,7 +1926,12 @@ const getActiveCardConfigForm = createConfigFormGetter(
     }
 
     _handleFavoriteSelectChange(event: Event): void {
-      if (!this._config?.show_favorites || this._isInEditor()) return;
+      if (
+        !this._config?.show_favorites ||
+        !this._config?.show_name ||
+        this._isInEditor()
+      )
+        return;
       const detail = (event as CustomEvent<{ value?: string | null }>).detail;
       const select = event.currentTarget as ValueElement | null;
       const path = event.composedPath();
@@ -2597,9 +2670,8 @@ const getActiveCardConfigForm = createConfigFormGetter(
     getGridOptions(): Record<string, number> {
       return {
         columns: 12,
-        rows: 4,
-        min_columns: 4,
-        min_rows: 1,
+        min_columns: 6,
+        min_rows: 4,
       };
     }
 

--- a/custom_components/city_visitor_parking/frontend/src/translations/en.json
+++ b/custom_components/city_visitor_parking/frontend/src/translations/en.json
@@ -8,6 +8,8 @@
   "editor.field.icon": "Icon",
   "editor.field.type": "Card type",
   "editor.field.display_options": "Display options",
+  "editor.field.default_license_plate": "Default license plate",
+  "editor.field.show_name": "Show name",
   "editor.field.show_favorites": "Show favorites",
   "editor.field.show_start_time": "Show start time",
   "editor.field.show_end_time": "Show end time",
@@ -16,6 +18,8 @@
   "editor.description.config_entry": "Optional. Choose a permit to link the card to. Leave empty to show a selector.",
   "editor.description.title": "Optional custom title shown at the top of the card.",
   "editor.description.icon": "Optional icon shown next to the title.",
+  "editor.description.default_license_plate": "Optional. Pre-fill the license plate field with this value when the form is empty or reset.",
+  "editor.description.show_name": "Show the name field in the reservation form.",
   "editor.description.show_favorites": "Show the favorites picker in the reservation form.",
   "editor.description.show_start_time": "Allow selecting a start time in the reservation form.",
   "editor.description.show_end_time": "Allow selecting an end time in the reservation form.",
@@ -72,7 +76,5 @@
   "message.reservation_update_failed": "We could not update your reservation.",
   "message.reservation_ended": "Your reservation was ended.",
   "message.reservation_end_failed": "We could not end your reservation.",
-  "placeholder.license_plate": "AA-123-B",
-  "editor.field.default_license_plate": "Default license plate",
-  "editor.description.default_license_plate": "Optional. Pre-fill the license plate field with this value when the form is empty or reset."
+  "placeholder.license_plate": "AA-123-B"
 }

--- a/custom_components/city_visitor_parking/frontend/src/translations/nl.json
+++ b/custom_components/city_visitor_parking/frontend/src/translations/nl.json
@@ -8,6 +8,8 @@
   "editor.field.icon": "Pictogram",
   "editor.field.type": "Kaarttype",
   "editor.field.display_options": "Weergaveopties",
+  "editor.field.default_license_plate": "Standaard kenteken",
+  "editor.field.show_name": "Toon naam",
   "editor.field.show_favorites": "Toon favorieten",
   "editor.field.show_start_time": "Toon starttijd",
   "editor.field.show_end_time": "Toon eindtijd",
@@ -16,6 +18,8 @@
   "editor.description.config_entry": "Optioneel. Kies een vergunning om de kaart te koppelen. Laat leeg om een keuzeveld te tonen.",
   "editor.description.title": "Optioneel. Aangepaste titel bovenaan de kaart.",
   "editor.description.icon": "Optioneel. Pictogram naast de titel.",
+  "editor.description.default_license_plate": "Optioneel. Vul het kentekenveld voorin met deze waarde als het formulier leeg of gereset is.",
+  "editor.description.show_name": "Toon het naamveld in het reserveringsformulier.",
   "editor.description.show_favorites": "Toon de favorietenkeuze in het reserveringsformulier.",
   "editor.description.show_start_time": "Sta het kiezen van een starttijd toe in het reserveringsformulier.",
   "editor.description.show_end_time": "Sta het kiezen van een eindtijd toe in het reserveringsformulier.",
@@ -72,7 +76,5 @@
   "message.reservation_update_failed": "We kunnen je reservering niet bijwerken.",
   "message.reservation_ended": "Je reservering is beëindigd.",
   "message.reservation_end_failed": "We kunnen je reservering niet beëindigen.",
-  "placeholder.license_plate": "AA-123-B",
-  "editor.field.default_license_plate": "Standaard kenteken",
-  "editor.description.default_license_plate": "Optioneel. Vul het kentekenveld voorin met deze waarde als het formulier leeg of gereset is."
+  "placeholder.license_plate": "AA-123-B"
 }


### PR DESCRIPTION
Adds a `show_name` card option to control whether the name field is shown in the reservation form.

Config:
```yaml
type: custom:city-visitor-parking-card
show_name: true
```

- Adds a `show_name` editor toggle
- Adds EN + NL translations for the new option
- Updates form rendering and related behavior when the name field is hidden
- Includes regenerated frontend dist assets