### PR TITLE
ci(labeler): add python label for custom_components and remove duplicate autolabeler rules

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -4,6 +4,11 @@ documentation:
           - "**/*.md"
           - "docs/**"
 
+python:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "custom_components/**"
+
 enhancement:
   - changed-files:
       - any-glob-to-any-file:

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -59,17 +59,6 @@ version-resolver:
       - "refactor"
       - "tests"
   default: patch
-autolabeler:
-  - label: "documentation"
-    files:
-      - "**/*.md"
-      - "docs/**"
-  - label: "tests"
-    files:
-      - "tests/**"
-  - label: "maintenance"
-    files:
-      - ".github/**"
 template: |
   🚗 City Visitor Parking is a Home Assistant integration that lets you register visitor parking permits directly from your dashboard.
 


### PR DESCRIPTION
## Summary

- Add `python` label for changes in `custom_components/**` in `labeler.yml`
- Remove duplicate `autolabeler` rules from `release-drafter.yml` (already handled by `labeler.yml`)

## Test plan

- [ ] Verify that PRs touching `custom_components/` automatically get the `python` label
- [ ] Verify release-drafter still works correctly without the duplicate autolabeler rules

🤖 Generated with [Claude Code](https://claude.com/claude-code)