### PR TITLE
feat: automatically include library version in release notes

### DIFF
--- a/.github/release-drafter-beta.yml
+++ b/.github/release-drafter-beta.yml
@@ -49,6 +49,8 @@ template: |
   **PyPI:** `FILL_IN_PYPI_VERSION_OR_LEAVE_EMPTY`
   **Commit:** `FILL_IN_COMMIT_SHA_OR_LEAVE_EMPTY`
 
+  **Built with:** `PYCVP_VERSION_PLACEHOLDER`
+
   ## 📋 Changes
 
   $CHANGES

--- a/.github/release-drafter-testing.yml
+++ b/.github/release-drafter-testing.yml
@@ -59,6 +59,8 @@ template: |
 
   **Commit:** `FILL_IN_COMMIT_SHA`
 
+  **Built with:** `PYCVP_VERSION_PLACEHOLDER`
+
   ## 📋 Changes
 
   $CHANGES

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -66,6 +66,10 @@ template: |
 
   $CHANGES
 
+  ## 🔗 pyCityVisitorParking
+
+  **Version:** `PYCVP_VERSION_PLACEHOLDER`
+
   ## 📦 Installation
 
   [![Open in HACS](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=sir-Unknown&repository=ha_City-Visitor-Parking&category=integration)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -269,9 +269,19 @@ jobs:
           pycvp_commit = os.environ.get("PYCVP_COMMIT", "")
           pycvp_pypi = os.environ.get("PYCVP_PYPI", "")
           if pycvp_commit:
-              new_reqs = [re.sub(r'[a-f0-9]{40}$', pycvp_commit, r) for r in data["requirements"]]
-              if new_reqs == data["requirements"]:
-                  raise ValueError("No pyCityVisitorParking SHA found in requirements to replace")
+              new_reqs = []
+              replaced = False
+              for r in data["requirements"]:
+                  if re.search(r'pycityvisitorparking', r, re.IGNORECASE):
+                      # Replace existing git SHA or PyPI version with the given commit
+                      if re.search(r'[a-f0-9]{40}', r):
+                          r = re.sub(r'[a-f0-9]{40}', pycvp_commit, r)
+                      else:
+                          r = re.sub(r'pycityvisitorparking==\S+', f'pycityvisitorparking @ git+https://github.com/sir-Unknown/pyCityVisitorParking@{pycvp_commit}', r, flags=re.IGNORECASE)
+                      replaced = True
+                  new_reqs.append(r)
+              if not replaced:
+                  raise ValueError("No pycityvisitorparking requirement found to replace")
               data["requirements"] = new_reqs
           elif pycvp_pypi:
               new_reqs = [re.sub(r'pycityvisitorparking==\S+', f'pycityvisitorparking=={pycvp_pypi}', r) for r in data["requirements"]]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -253,6 +253,7 @@ jobs:
           [ -n "$PYPI" ]   && echo "Found pyCityVisitorParking PyPI version: $PYPI" || true
 
       - name: Build release asset
+        id: build
         env:
           VERSION: ${{ steps.version.outputs.version }}
           PYCVP_COMMIT: ${{ steps.pycvp.outputs.commit }}
@@ -288,6 +289,10 @@ jobs:
               if new_reqs == data["requirements"]:
                   raise ValueError("No pycityvisitorparking==... requirement found to replace")
               data["requirements"] = new_reqs
+          # Write the final requirement back to GITHUB_OUTPUT
+          pycvp_req = next((r for r in data["requirements"] if re.search(r'pycityvisitorparking', r, re.IGNORECASE)), "")
+          with open(os.environ["GITHUB_OUTPUT"], "a") as f:
+              f.write(f"pycvp_req={pycvp_req}\n")
           p.write_text(json.dumps(data, indent=2) + "\n")
           PYEOF
           cd /tmp/release-build && zip -r "$GITHUB_WORKSPACE/city_visitor_parking.zip" .
@@ -296,6 +301,15 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           RELEASE_TAG: ${{ needs.validate.outputs.tag }}
         run: gh release upload "$RELEASE_TAG" city_visitor_parking.zip --clobber
+      - name: Update release body with pyCityVisitorParking version
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ needs.validate.outputs.tag }}
+          PYCVP_REQ: ${{ steps.build.outputs.pycvp_req }}
+        run: |
+          body=$(gh release view "$RELEASE_TAG" --json body --jq '.body')
+          updated=$(echo "$body" | sed "s|PYCVP_VERSION_PLACEHOLDER|${PYCVP_REQ}|g")
+          gh release edit "$RELEASE_TAG" --notes "$updated"
 
   skip-release:
     needs: [validate]


### PR DESCRIPTION
## Summary

- All release-drafter templates now include a `PYCVP_VERSION_PLACEHOLDER` in a `## 🔗 pyCityVisitorParking` section
- After building the zip, the release workflow replaces the placeholder with the actual requirement from the built `manifest.json` (e.g. `pycityvisitorparking==0.5.23` or a `git+` URL)
- Also fixes beta builds: when a commit SHA is specified but the manifest uses a `pycityvisitorparking==x.y.z` requirement, it is replaced on the fly with a `git+https://` URL

## Test plan

- [ ] Merge and re-run the release workflow for `v0.1.36-beta.3` — release notes should show the actual library version under `## 🔗 pyCityVisitorParking`

🤖 Generated with [Claude Code](https://claude.com/claude-code)