### PR TITLE
docs: document frontend modules and data contract

### DIFF
--- a/custom_components/city_visitor_parking/frontend/dist/city-visitor-parking-card.js
+++ b/custom_components/city_visitor_parking/frontend/dist/city-visitor-parking-card.js
@@ -643,19 +643,6 @@ var ensureTranslations = async (target) => {
   await loadPromise;
   translationsInFlight.delete(language);
 };
-var resolveTranslationValue = (strings, key) => {
-  const directValue = strings[key];
-  if (typeof directValue === "string") return directValue;
-  const cardStrings = strings.card;
-  if (!cardStrings || typeof cardStrings !== "object") return null;
-  const parts = key.split(".");
-  let current = cardStrings;
-  for (const part of parts) {
-    if (!current || typeof current !== "object") return null;
-    current = current[part];
-  }
-  return typeof current === "string" ? current : null;
-};
 var localize = (target, key) => {
   const language = getLanguage(target);
   const strings = translationsCache.get(language) || translationsCache.get(DEFAULT_LANGUAGE);
@@ -667,11 +654,16 @@ var localize = (target, key) => {
   }
   const cachedValue = cachedLookups.get(key);
   if (cachedValue !== void 0) return cachedValue;
-  const resolved = resolveTranslationValue(strings, key) ?? key;
+  const resolved = typeof strings[key] === "string" ? strings[key] : key;
   cachedLookups.set(key, resolved);
   return resolved;
 };
 var createLocalize = (getHass) => (key, ..._args) => localize(getHass(), key);
+var getHassLanguage = (hass) => {
+  if (typeof hass?.language === "string" && hass.language) return hass.language;
+  const loc = hass?.locale;
+  return typeof loc?.language === "string" ? loc.language : void 0;
+};
 
 // src/helpers.ts
 var DOMAIN = "city_visitor_parking";
@@ -1500,7 +1492,7 @@ var CityVisitorParkingNewReservationCard = class extends BaseLocalizedCard {
     const prev = this._prevHaState;
     this._prevHaState = hass.config?.state;
     this._hass = hass;
-    const nextLanguage = hass.language || navigator.language || "en";
+    const nextLanguage = getHassLanguage(hass) || navigator.language || "en";
     if (nextLanguage !== this._translationsLanguage || !this._translationsReady) {
       this._translationsReady = false;
       void ensureTranslations(this._hass).then(() => {
@@ -2517,6 +2509,7 @@ var CityVisitorParkingActiveCardEditor = class extends BaseCardEditor {
   render() {
     if (!this.hass) return b2``;
     const localizeTarget = this.hass;
+    void ensureTranslations(localizeTarget);
     const { computeLabel, computeHelper } = buildFormHelpers2(
       localizeTarget,
       "active_editor"

--- a/custom_components/city_visitor_parking/frontend/src/base.ts
+++ b/custom_components/city_visitor_parking/frontend/src/base.ts
@@ -1,3 +1,4 @@
+/** Shared Lit base classes and registration helpers for the custom cards. */
 import { LitElement } from "lit";
 import type {
   HomeAssistant,
@@ -20,6 +21,7 @@ import {
 
 export { LitElement };
 
+/** Batches repeated update requests into a single animation frame. */
 export const createRenderScheduler = (
   requestUpdate: () => void,
 ): (() => void) => {
@@ -33,6 +35,7 @@ export const createRenderScheduler = (
   };
 };
 
+/** Detects whether a node is rendered inside a Lovelace card editor context. */
 export const isInEditor = (startNode: Node): boolean => {
   const selector =
     "hui-card-preview, hui-card-picker, hui-card-element-editor, " +
@@ -54,6 +57,7 @@ export const isInEditor = (startNode: Node): boolean => {
   return false;
 };
 
+/** Base class for cards that need localized text and shared status messaging. */
 export abstract class BaseLocalizedCard<TConfig> extends LitElement {
   _config: TConfig | null = null;
   _hass: HomeAssistant | null = null;
@@ -81,6 +85,7 @@ export abstract class BaseLocalizedCard<TConfig> extends LitElement {
   }
 }
 
+/** Defines a custom element in the active registries when it is still missing. */
 export const defineElementIfMissing = (
   tagName: string,
   ctor: CustomElementConstructor,
@@ -93,6 +98,7 @@ export const defineElementIfMissing = (
   }
 };
 
+/** Registers a Lovelace custom card and keeps its picker metadata up to date. */
 export const registerCustomCard = (
   cardType: string,
   ctor: CustomElementConstructor,
@@ -113,6 +119,7 @@ export const registerCustomCard = (
   win.customCards.push({ type: cardType, name, description });
 };
 
+/** Registers a custom card using translated picker labels when available. */
 export const registerCustomCardWithTranslations = (
   cardType: string,
   ctor: CustomElementConstructor,
@@ -133,6 +140,7 @@ export const registerCustomCardWithTranslations = (
   void ensureTranslations(hass).then(registerCard);
 };
 
+/** Hides a card type from the Lovelace picker without affecting existing cards. */
 export const hideCustomCardFromPicker = (cardType: string): void => {
   const applyPatch = (pickerCtor: PickerCtor): void => {
     const { prototype } = pickerCtor;
@@ -166,6 +174,7 @@ export const hideCustomCardFromPicker = (cardType: string): void => {
   }
 };
 
+/** Base class for lightweight card editors backed by `ha-form`. */
 export abstract class BaseCardEditor<TConfig> extends LitElement {
   public hass?: unknown;
   protected _config?: TConfig;

--- a/custom_components/city_visitor_parking/frontend/src/card-active.ts
+++ b/custom_components/city_visitor_parking/frontend/src/card-active.ts
@@ -1,3 +1,4 @@
+/** Lovelace card for listing and updating active visitor parking reservations. */
 import { css, html, nothing, type TemplateResult } from "lit";
 import type { DeviceEntry, HomeAssistant, ValueElement } from "./types";
 import { ensureTranslations, getGlobalHass, localize } from "./translations";
@@ -53,6 +54,7 @@ type CardConfig = {
   config_entry_id?: string;
 };
 
+/** Interactive card that shows active reservations for the selected permit. */
 class CityVisitorParkingActiveCard extends BaseLocalizedCard<CardConfig> {
   static styles = [
     BASE_CARD_STYLES,

--- a/custom_components/city_visitor_parking/frontend/src/card-parking.ts
+++ b/custom_components/city_visitor_parking/frontend/src/card-parking.ts
@@ -1,3 +1,4 @@
+/** Lovelace card for creating visitor parking reservations and favorites. */
 import { css, html, nothing, type TemplateResult } from "lit";
 import { keyed } from "lit/directives/keyed.js";
 import type {
@@ -8,7 +9,11 @@ import type {
   ZoneStatus,
   ZoneStatusResponse,
 } from "./types";
-import { ensureTranslations, getGlobalHass } from "./translations";
+import {
+  ensureTranslations,
+  getGlobalHass,
+  getHassLanguage,
+} from "./translations";
 import {
   DOMAIN,
   RESERVATION_ENDED_EVENT,
@@ -79,6 +84,7 @@ const INPUT_VALUE_IDS = new Set([
 ]);
 const CHANGE_VALUE_IDS = new Set(["startDateTime", "endDateTime"]);
 
+/** Interactive card that starts reservations and manages favorites for one permit. */
 class CityVisitorParkingNewReservationCard extends BaseLocalizedCard<CardConfig> {
   static styles = [
     BASE_CARD_STYLES,
@@ -246,8 +252,7 @@ class CityVisitorParkingNewReservationCard extends BaseLocalizedCard<CardConfig>
     const prev = this._prevHaState;
     this._prevHaState = hass.config?.state;
     this._hass = hass;
-    const nextLanguage =
-      (hass.language as string | undefined) || navigator.language || "en";
+    const nextLanguage = getHassLanguage(hass) || navigator.language || "en";
     if (
       nextLanguage !== this._translationsLanguage ||
       !this._translationsReady

--- a/custom_components/city_visitor_parking/frontend/src/editor-active.ts
+++ b/custom_components/city_visitor_parking/frontend/src/editor-active.ts
@@ -1,3 +1,4 @@
+/** Editor schema helpers for the active-reservations Lovelace card. */
 import { html, type TemplateResult } from "lit";
 import type {
   ActiveParkingCardEditorConfig,
@@ -5,13 +6,14 @@ import type {
   LocalizeTarget,
 } from "./types";
 import { DOMAIN } from "./helpers";
-import { localize } from "./translations";
+import { ensureTranslations, localize } from "./translations";
 import { BaseCardEditor, defineElementIfMissing } from "./base";
 import { buildCardTypeOptions, createConfigFormGetter } from "./editor-parking";
 
 type LocalizeFunc = (key: string, ...args: Array<string | number>) => string;
 type FormSchema = { name: string };
 
+/** Builds localized field-label and helper-text resolvers for `ha-form`. */
 const buildFormHelpers = (
   localizeTarget: LocalizeTarget | LocalizeFunc,
   prefix: string,
@@ -60,10 +62,12 @@ const buildActiveCardEditorSchema = (
   },
 ];
 
+/** Lovelace editor element for configuring the active-reservations card. */
 export class CityVisitorParkingActiveCardEditor extends BaseCardEditor<ActiveParkingCardEditorConfig> {
   protected render(): TemplateResult {
     if (!this.hass) return html``;
     const localizeTarget = this.hass;
+    void ensureTranslations(localizeTarget);
     const { computeLabel, computeHelper } = buildFormHelpers(
       localizeTarget,
       "active_editor",
@@ -99,6 +103,7 @@ defineElementIfMissing(
   CityVisitorParkingActiveCardEditor,
 );
 
+/** Returns the config-form schema for the active-reservations card. */
 export const getActiveCardConfigForm = createConfigFormGetter(
   "active_editor",
   (cardTypeOptions, target) =>

--- a/custom_components/city_visitor_parking/frontend/src/editor-parking.ts
+++ b/custom_components/city_visitor_parking/frontend/src/editor-parking.ts
@@ -1,3 +1,4 @@
+/** Editor schema helpers for the new-reservation Lovelace card. */
 import { html, type TemplateResult } from "lit";
 import type {
   CardEditorFormSchema,
@@ -12,6 +13,7 @@ import { BaseCardEditor, defineElementIfMissing } from "./base";
 
 type LocalizeFunc = (key: string, ...args: Array<string | number>) => string;
 
+/** Builds localized field-label and helper-text resolvers for `ha-form`. */
 const buildFormHelpers = (
   localizeTarget: LocalizeTarget | LocalizeFunc,
   prefix: string,
@@ -31,6 +33,7 @@ const buildFormHelpers = (
   };
 };
 
+/** Returns the selectable card types shown by the Lovelace card editor. */
 export const buildCardTypeOptions = (
   localizeTarget: LocalizeTarget | LocalizeFunc,
   prefix: string,
@@ -84,6 +87,7 @@ const buildCardEditorSchema = (
   },
 ];
 
+/** Lovelace editor element for configuring the new-reservation card. */
 export class CityVisitorParkingCardEditor extends BaseCardEditor<ParkingCardEditorConfig> {
   protected render(): TemplateResult {
     if (!this.hass) return html``;
@@ -123,6 +127,7 @@ defineElementIfMissing(
   CityVisitorParkingCardEditor,
 );
 
+/** Creates the async config-form getter used by Lovelace card metadata APIs. */
 export const createConfigFormGetter =
   (
     prefix: string,
@@ -150,6 +155,7 @@ export const createConfigFormGetter =
     };
   };
 
+/** Returns the config-form schema for the new-reservation card. */
 export const getCardConfigForm = createConfigFormGetter(
   "editor",
   (cardTypeOptions) => buildCardEditorSchema(cardTypeOptions, false),

--- a/custom_components/city_visitor_parking/frontend/src/helpers.ts
+++ b/custom_components/city_visitor_parking/frontend/src/helpers.ts
@@ -1,3 +1,4 @@
+/** Shared frontend helpers for permit selection, status handling, and formatting. */
 import type {
   DeviceEntry,
   FavoriteItem,
@@ -9,11 +10,13 @@ import type {
 } from "./types";
 import { localize } from "./translations";
 
+/** Integration domain used for selectors, websocket calls, and device matching. */
 export const DOMAIN = "city_visitor_parking";
 export const RESERVATION_STARTED_EVENT =
   "city-visitor-parking-reservation-started";
 export const RESERVATION_ENDED_EVENT = "city-visitor-parking-reservation-ended";
 
+/** Empty zone state used before a status payload has been loaded. */
 export const EMPTY_ZONE_STATUS: ZoneStatus = {
   state: null,
   kind: null,
@@ -23,15 +26,17 @@ export const EMPTY_ZONE_STATUS: ZoneStatus = {
   balanceUnit: null,
 };
 
+/** Normalizes free-form text for case-insensitive matching. */
 export const normalizeMatchValue = (value: string | undefined | null): string =>
   String(value ?? "")
     .trim()
     .toLowerCase();
 
-// Strips all non-alphanumeric characters for matching purposes only (not for storage or display).
+/** Strips non-alphanumeric characters for matching only, never for storage or display. */
 export const normalizePlateValue = (value: string | undefined | null): string =>
   normalizeMatchValue(value).replace(/[^a-z0-9]/g, "");
 
+/** Builds lookup maps so favorite matching stays cheap during card interaction. */
 export const createFavoriteIndex = (favorites: FavoriteItem[]) => {
   const byPlate = new Map<string, FavoriteItem>();
   const byPlateName = new Map<string, FavoriteItem>();
@@ -49,6 +54,7 @@ export const createFavoriteIndex = (favorites: FavoriteItem[]) => {
   return { byPlate, byPlateName, byValue };
 };
 
+/** Clears transient favorite-action flags after a request or form reset. */
 export const clearFavoriteTransientState = (context: {
   _pendingRemoveFavoriteId: string | null;
   _favoriteRemoveInFlight: boolean;
@@ -63,6 +69,7 @@ export const clearFavoriteTransientState = (context: {
   });
 };
 
+/** Invalidates cached favorites and optionally resets retry/loading state. */
 export const invalidateFavoritesCache = (
   context: {
     _favoritesLoadedFor: string | null;
@@ -77,6 +84,7 @@ export const invalidateFavoritesCache = (
   if (options?.clearLoading) context._favoritesLoading = false;
 };
 
+/** Tracks whether permit defaults still need to be applied to the form. */
 export const setPendingPermitDefaults = (
   context: {
     _pendingPermitDefaultsEntryId: string | null;
@@ -91,6 +99,7 @@ export const setPendingPermitDefaults = (
   });
 };
 
+/** Copies a normalized zone status payload into card instance state fields. */
 export const applyZoneStatus = (
   context: {
     _zoneState: ZoneStatus["state"];
@@ -112,12 +121,14 @@ export const applyZoneStatus = (
   });
 };
 
+/** Returns whether a config entry should be hidden from permit selection. */
 export const isPermitEntryDisabled = (entry: PermitEntry): boolean =>
   Boolean(entry.disabled_by) ||
   (entry.state != null &&
     entry.state !== "loaded" &&
     entry.state !== "setup_in_progress");
 
+/** Converts config entries into sorted Lovelace selector options. */
 export const buildPermitOptions = (entries: PermitEntry[]): PermitOption[] =>
   entries
     .map((entry) => ({
@@ -127,6 +138,7 @@ export const buildPermitOptions = (entries: PermitEntry[]): PermitOption[] =>
     }))
     .sort((first, second) => first.label.localeCompare(second.label));
 
+/** Maps config entry ids to their display titles for device labeling. */
 export const buildPermitTitleMap = (
   entries: PermitEntry[],
 ): Map<string, string> =>
@@ -134,6 +146,7 @@ export const buildPermitTitleMap = (
     entries.map((entry) => [entry.entry_id, entry.title || entry.entry_id]),
   );
 
+/** Fetches config entries for this integration through Home Assistant websocket API. */
 export const fetchPermitEntries = async (
   hass: HomeAssistant,
 ): Promise<PermitEntry[]> =>
@@ -143,6 +156,7 @@ export const fetchPermitEntries = async (
     domain: DOMAIN,
   });
 
+/** Resolves a user-facing permit label for each device tied to a config entry. */
 export const resolvePermitLabelsByDevice = (
   devices: DeviceEntry[],
   entryTitles: Map<string, string>,
@@ -159,6 +173,7 @@ export const resolvePermitLabelsByDevice = (
   return labels;
 };
 
+/** Extracts the best available error message, falling back to a translation key. */
 export const errorMessage = (
   err: unknown,
   fallbackKey: string,
@@ -173,6 +188,7 @@ export const errorMessage = (
   return localizeFn(fallbackKey);
 };
 
+/** Creates an error formatter bound to the current Home Assistant localization context. */
 export const createErrorMessage =
   (
     getHass: () => LocalizeTarget | null | undefined,
@@ -180,15 +196,19 @@ export const createErrorMessage =
   (err: unknown, fallbackKey: string) =>
     errorMessage(err, fallbackKey, (key) => localize(getHass(), key));
 
+/** Pads a numeric value to two digits for date and time formatting. */
 export const pad = (value: number | string): string =>
   String(value).padStart(2, "0");
 
+/** Formats a `Date` as a local `YYYY-MM-DD` string. */
 export const formatDate = (date: Date): string =>
   `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}`;
 
+/** Formats a `Date` as a local datetime string accepted by HA form inputs. */
 export const formatDateTimeLocal = (date: Date): string =>
   `${formatDate(date)}T${pad(date.getHours())}:${pad(date.getMinutes())}`;
 
+/** Formats an optional ISO-like value for datetime-local input controls. */
 export const formatOptionalDateTimeLocal = (
   value: string | undefined | null,
 ): string => {
@@ -196,6 +216,7 @@ export const formatOptionalDateTimeLocal = (
   return date ? formatDateTimeLocal(date) : "";
 };
 
+/** Parses a date-time string into a `Date`, returning `null` for invalid input. */
 export const parseDateTimeValue = (
   value: string | undefined | null,
 ): Date | null => {
@@ -204,10 +225,12 @@ export const parseDateTimeValue = (
   return Number.isNaN(date.getTime()) ? null : date;
 };
 
+/** Safely reads the selected config entry id from a card config object. */
 export const getConfigEntryId = (
   config: { config_entry_id?: string | null } | null | undefined,
 ): string | null => config?.config_entry_id ?? null;
 
+/** Filters HA devices down to those owned by this integration domain. */
 export const filterDomainDevices = (devices: DeviceEntry[]): DeviceEntry[] =>
   devices.filter((device) =>
     (device.identifiers ?? []).some(
@@ -215,6 +238,7 @@ export const filterDomainDevices = (devices: DeviceEntry[]): DeviceEntry[] =>
     ),
   );
 
+/** Reuses an in-flight async loader so duplicate requests share the same promise. */
 export const makeDedupedLoader = <T>(
   getPromise: () => Promise<T> | null,
   setPromise: (p: Promise<T> | null) => void,
@@ -227,6 +251,7 @@ export const makeDedupedLoader = <T>(
   return promise;
 };
 
+/** Reads a selector value from a Home Assistant event with an element fallback. */
 export const extractEventValue = (
   event: Event,
   fallbackElement?: (HTMLElement & { value?: string }) | null,
@@ -237,10 +262,12 @@ export const extractEventValue = (
     : (fallbackElement?.value ?? "");
 };
 
+/** Returns whether Home Assistant has finished starting up. */
 export const isHassRunning = (
   hass: { config?: { state?: string } } | null | undefined,
 ): boolean => hass?.config?.state === "RUNNING";
 
+/** Formats remaining permit balance as a badge label and matching icon. */
 export const formatBalanceLabel = (
   remainingMinutes: number,
   balanceUnit: string | null,

--- a/custom_components/city_visitor_parking/frontend/src/index.ts
+++ b/custom_components/city_visitor_parking/frontend/src/index.ts
@@ -1,4 +1,4 @@
-// Entry point — imports trigger side-effects (custom element registration).
+/** Registers the frontend cards and editors through module side effects. */
 import "./card-parking";
 import "./card-active";
 import "./editor-parking";

--- a/custom_components/city_visitor_parking/frontend/src/translations.ts
+++ b/custom_components/city_visitor_parking/frontend/src/translations.ts
@@ -1,3 +1,4 @@
+/** Translation loading and lookup helpers for the custom frontend bundle. */
 import type { LocalizeFunc, LocalizeTarget, TranslationObject } from "./types";
 
 const DEFAULT_LANGUAGE = "en";
@@ -6,6 +7,7 @@ const translationsCache = new Map<string, TranslationObject>();
 const translationsInFlight = new Map<string, Promise<void>>();
 const translationLookupCache = new Map<string, Map<string, string>>();
 
+/** Returns the globally injected Home Assistant object when available. */
 export const getGlobalHass = <T>(): T | undefined =>
   (window as Window & { hass?: T }).hass;
 
@@ -81,25 +83,7 @@ export const ensureTranslations = async (
   translationsInFlight.delete(language);
 };
 
-type TranslationValue = string | TranslationObject | undefined;
-
-const resolveTranslationValue = (
-  strings: TranslationObject,
-  key: string,
-): string | null => {
-  const directValue = strings[key];
-  if (typeof directValue === "string") return directValue;
-  const cardStrings = strings.card;
-  if (!cardStrings || typeof cardStrings !== "object") return null;
-  const parts = key.split(".");
-  let current: TranslationValue = cardStrings as TranslationObject;
-  for (const part of parts) {
-    if (!current || typeof current !== "object") return null;
-    current = (current as TranslationObject)[part] as TranslationValue;
-  }
-  return typeof current === "string" ? current : null;
-};
-
+/** Resolves a translation key from the cached frontend translation bundle. */
 export const localize = (target: LocalizeTarget, key: string): string => {
   const language = getLanguage(target);
   const strings =
@@ -112,11 +96,12 @@ export const localize = (target: LocalizeTarget, key: string): string => {
   }
   const cachedValue = cachedLookups.get(key);
   if (cachedValue !== undefined) return cachedValue;
-  const resolved = resolveTranslationValue(strings, key) ?? key;
+  const resolved = typeof strings[key] === "string" ? strings[key] : key;
   cachedLookups.set(key, resolved);
   return resolved;
 };
 
+/** Creates a localization helper that always reads the latest HA context lazily. */
 export const createLocalize =
   (
     getHass: () => LocalizeTarget | null | undefined,
@@ -124,6 +109,7 @@ export const createLocalize =
   (key: string, ..._args: Array<string | number>) =>
     localize(getHass(), key);
 
+/** Extracts the preferred language from a Home Assistant-like object. */
 export const getHassLanguage = (
   hass: { language?: unknown; locale?: unknown } | null | undefined,
 ): string | undefined => {

--- a/custom_components/city_visitor_parking/frontend/src/types.ts
+++ b/custom_components/city_visitor_parking/frontend/src/types.ts
@@ -1,8 +1,10 @@
+/** Shared frontend type definitions for cards, editors, and translations. */
 export type LocalizeFunc = (
   key: string,
   ...args: Array<string | number>
 ) => string;
 
+/** Value accepted anywhere frontend code can localize text. */
 export type LocalizeTarget =
   | {
       localize?: LocalizeFunc;
@@ -13,11 +15,14 @@ export type LocalizeTarget =
   | null
   | undefined;
 
+/** Recursive JSON-like translation value used by the frontend cache. */
 export type TranslationValue = string | TranslationObject;
+/** Object shape used for loaded translation files. */
 export interface TranslationObject {
   [key: string]: TranslationValue;
 }
 
+/** Minimal subset of the Home Assistant frontend object used by the cards. */
 export type HomeAssistant = {
   callWS: <T = unknown>(msg: Record<string, unknown>) => Promise<T>;
   callService: <T = unknown>(
@@ -31,6 +36,7 @@ export type HomeAssistant = {
   locale?: Record<string, unknown>;
 };
 
+/** Home Assistant device entry fields needed for integration device routing. */
 export type DeviceEntry = {
   id: string;
   name?: string | null;
@@ -38,6 +44,7 @@ export type DeviceEntry = {
   config_entries?: string[];
 };
 
+/** Config entry fields used for permit selection in the frontend. */
 export type PermitEntry = {
   entry_id: string;
   title?: string | null;
@@ -45,21 +52,25 @@ export type PermitEntry = {
   disabled_by?: string | null;
 };
 
+/** Display-ready permit option for selector components. */
 export type PermitOption = {
   id: string;
   label: string;
   disabled: boolean;
 };
 
+/** Lightweight favorite data accepted by form and selector helpers. */
 export type FavoriteOption = {
   id?: string;
   license_plate?: string;
   name?: string;
 };
+/** Favorite payload shape returned by service and websocket responses. */
 export type FavoriteItem = FavoriteOption & {
   [key: string]: unknown;
 };
 
+/** Normalized zone status state consumed by the reservation card UI. */
 export type ZoneStatus = {
   state: "chargeable" | "free" | null;
   kind: "current" | "next" | null;
@@ -69,19 +80,72 @@ export type ZoneStatus = {
   balanceUnit: string | null;
 };
 
+/**
+ * Payload returned by the Python websocket handler `city_visitor_parking/status`.
+ *
+ * `build_status_payload()` in `payloads.py` always returns this full key set.
+ * Fields use `null` when a value is intentionally unavailable, instead of
+ * omitting the key entirely.
+ */
+export type ZoneStatusResponse = {
+  /**
+   * Current effective zone state after applying weekday overrides.
+   * Guaranteed to be `"chargeable"` or `"free"`.
+   */
+  state: "chargeable" | "free";
+
+  /**
+   * Describes the effective window referenced by `window_start`/`window_end`.
+   * `"current"` is only returned while the zone is chargeable right now.
+   * `"next"` is only returned while the zone is currently free and a next
+   * chargeable window exists today or later.
+   * `null` means there is no relevant current/next effective window.
+   */
+  window_kind: "current" | "next" | null;
+
+  /**
+   * UTC ISO8601 start timestamp for the effective window selected by
+   * `window_kind`, or `null` when no effective window is available.
+   */
+  window_start: string | null;
+
+  /**
+   * UTC ISO8601 end timestamp for the effective window selected by
+   * `window_kind`, or `null` when no effective window is available.
+   */
+  window_end: string | null;
+
+  /**
+   * Non-negative remaining permit balance in minutes.
+   * `build_status_payload()` clamps this value to `0` or higher.
+   */
+  remaining_minutes: number;
+
+  /**
+   * Permit balance unit from coordinator data, or `null` when the provider
+   * does not expose a string balance unit.
+   */
+  balance_unit: string | null;
+};
+
+/** HTMLElement variant used for simple input-like value access. */
 export type ValueElement = HTMLElement & { value?: string };
+/** Progress-button instance with imperative success and error helpers. */
 export type ProgressButtonElement = HTMLElement & {
   actionSuccess?: () => void;
   actionError?: () => void;
 };
 
+/** Severity levels for temporary in-card status messaging. */
 export type StatusType = "info" | "warning" | "success";
+/** Mutable status state stored on base card classes. */
 export type StatusState = {
   message: string;
   type: StatusType;
   clearHandle: number | null;
 };
 
+/** Home Assistant card-picker element shape used for runtime patching. */
 export type PickerCtor = CustomElementConstructor & {
   prototype: {
     _loadCards?: () => void;
@@ -90,9 +154,12 @@ export type PickerCtor = CustomElementConstructor & {
   };
 };
 
+/** Minimal form schema entry used by label/helper resolvers. */
 export type FormSchema = { name: string };
+/** Select-option tuple consumed by Home Assistant selector definitions. */
 export type SelectOption = [string, string];
 
+/** Config shape for the new-reservation Lovelace card editor. */
 export type ParkingCardEditorConfig = {
   type: string;
   title?: string;
@@ -105,22 +172,13 @@ export type ParkingCardEditorConfig = {
   config_entry_id?: string;
 };
 
+/** Generic schema payload returned to Lovelace card config forms. */
 export type CardEditorFormSchema = ReadonlyArray<Record<string, unknown>>;
 
+/** Config shape for the active-reservations Lovelace card editor. */
 export type ActiveParkingCardEditorConfig = {
   type: string;
   title?: string;
   icon?: string;
   config_entry_id?: string;
-};
-
-// ZoneStatusResponse: shape of the payload returned by the Python
-// websocket handler city_visitor_parking/status (see payloads.py build_status_payload).
-export type ZoneStatusResponse = {
-  state?: string | null;
-  window_kind?: string | null;
-  window_start?: string | null;
-  window_end?: string | null;
-  remaining_minutes?: number | null;
-  balance_unit?: string | null;
 };

--- a/custom_components/city_visitor_parking/frontend/src/ui.ts
+++ b/custom_components/city_visitor_parking/frontend/src/ui.ts
@@ -1,3 +1,4 @@
+/** Shared presentation helpers and templates used by both Lovelace cards. */
 import { css, html, nothing, type TemplateResult } from "lit";
 import type {
   FavoriteOption,
@@ -12,6 +13,7 @@ import { DOMAIN, formatBalanceLabel, normalizeMatchValue } from "./helpers";
 
 export { css };
 
+/** Baseline card styling shared by the reservation and active-reservations cards. */
 export const BASE_CARD_STYLES = css`
   :host {
     display: block;
@@ -65,12 +67,14 @@ export const BASE_CARD_STYLES = css`
   }
 `;
 
+/** Creates the mutable status object used for temporary banner feedback. */
 export const createStatusState = (): StatusState => ({
   message: "",
   type: "info",
   clearHandle: null,
 });
 
+/** Triggers visual success or error feedback on a rendered progress button. */
 export const triggerProgressButtonFeedback = async (
   host: {
     updateComplete: Promise<boolean>;
@@ -91,6 +95,7 @@ export const triggerProgressButtonFeedback = async (
   }
 };
 
+/** Updates the shared status banner state and optionally auto-clears it later. */
 export const setStatusState = (
   state: StatusState,
   message: string,
@@ -114,6 +119,7 @@ export const setStatusState = (
   }
 };
 
+/** Clears the shared status banner and cancels any pending auto-clear timer. */
 export const clearStatusState = (
   state: StatusState,
   requestRender: () => void,
@@ -128,13 +134,16 @@ export const clearStatusState = (
   requestRender();
 };
 
+/** Home Assistant core translation key for the startup warning message. */
 export const HA_STARTING_MESSAGE_KEY = "ui.panel.lovelace.warning.starting";
 
+/** Reads a card picker translation and returns `null` when it is unresolved. */
 export const getCardText = (key: string): string | null => {
   const value = localize(getGlobalHass<LocalizeTarget>(), key);
   return value === key ? null : value;
 };
 
+/** Builds the loading message shown while Home Assistant or translations initialize. */
 export const getLoadingMessage = (
   hass: LocalizeTarget | null | undefined,
 ): string => {
@@ -146,6 +155,7 @@ export const getLoadingMessage = (
   return message === key ? "" : message;
 };
 
+/** Renders a minimal warning card while the frontend is not ready yet. */
 export const renderLoadingCard = (
   hass: LocalizeTarget | null | undefined,
 ): TemplateResult => {
@@ -161,6 +171,7 @@ export const renderLoadingCard = (
   `;
 };
 
+/** Renders the standard card header with an optional icon. */
 export const renderCardHeader = (
   title: string,
   icon: string | undefined,
@@ -176,6 +187,7 @@ export const renderCardHeader = (
   `;
 };
 
+/** Renders the permit selector or a read-only preview equivalent. */
 export const renderPermitSelect = (params: {
   hass: HomeAssistant | null | undefined;
   label: string;
@@ -216,6 +228,7 @@ export const renderPermitSelect = (params: {
   `;
 };
 
+/** Renders the name/favorite selector, including preview and error states. */
 export const renderFavoriteSelect = (params: {
   showName: boolean;
   showFavorites: boolean;
@@ -315,6 +328,7 @@ export const renderFavoriteSelect = (params: {
   `;
 };
 
+/** Renders the favorite action controls together with the start button area. */
 export const renderFavoriteActionRow = (params: {
   showFavorites: boolean;
   showAddFavorite: boolean;


### PR DESCRIPTION
## Summary
- document the shared frontend TypeScript modules with concise JSDoc comments
- move and tighten the `ZoneStatusResponse` contract in `frontend/src/types.ts`
- rebuild the bundled frontend asset so the distributed card stays in sync

## Why
This follow-up keeps the split frontend modules easier to navigate and documents the Python-to-TypeScript status payload contract inline, without changing runtime behavior.

## Impact
Developers get clearer module intent, helper usage, and card/editor type documentation while the generated frontend bundle remains aligned with the source changes.

## Validation
- pre-commit hooks during `git commit`
- `yarn lint`
- `yarn build`
- frontend types
- frontend test
