### PR TITLE
refactor: rename remaining minutes field to support non-time permit types

### DIFF
--- a/custom_components/city_visitor_parking/coordinator.py
+++ b/custom_components/city_visitor_parking/coordinator.py
@@ -175,7 +175,7 @@ class CityVisitorParkingCoordinator(DataUpdateCoordinator[CoordinatorData]):
             )
             raise UpdateFailed("Unexpected error") from err
 
-        remaining_minutes = _normalize_remaining_minutes(permit)
+        remaining_balance = _normalize_remaining_balance(permit)
         balance_unit = get_attr(permit, "balance_unit")
         zone_validity = _normalize_zone_validity(permit)
         normalized_reservations = _normalize_reservations(reservations)
@@ -190,7 +190,7 @@ class CityVisitorParkingCoordinator(DataUpdateCoordinator[CoordinatorData]):
 
         data = CoordinatorData(
             permit_id=self._permit_id,
-            permit_remaining_minutes=remaining_minutes,
+            permit_remaining_balance=remaining_balance,
             permit_balance_unit=balance_unit if isinstance(balance_unit, str) else None,
             zone_validity=tuple(zone_validity),
             reservations=tuple(normalized_reservations),
@@ -355,7 +355,7 @@ def _normalize_zone_validity(permit: Permit) -> list[TimeRange]:
     ]
 
 
-def _normalize_remaining_minutes(permit: Permit) -> float:
+def _normalize_remaining_balance(permit: Permit) -> float:
     """Normalize remaining balance (minutes, times, or monetary amount)."""
     raw = get_attr(permit, "remaining_balance")
     if raw is None:

--- a/custom_components/city_visitor_parking/frontend/dist/city-visitor-parking-card.js
+++ b/custom_components/city_visitor_parking/frontend/dist/city-visitor-parking-card.js
@@ -788,7 +788,7 @@ var extractEventValue = (event, fallbackElement) => {
   return detail != null && "value" in detail ? detail.value ?? "" : fallbackElement?.value ?? "";
 };
 var isHassRunning = (hass) => hass?.config?.state === "RUNNING";
-var formatBalanceLabel = (remainingMinutes, balanceUnit) => {
+var formatBalanceLabel = (remainingMinutes, balanceUnit, localize2) => {
   const isMonetary = balanceUnit !== null && balanceUnit !== "TIMES" && balanceUnit !== "MINUTE";
   if (isMonetary) {
     const formatted = Number.isInteger(remainingMinutes) ? String(remainingMinutes) : remainingMinutes.toFixed(2);
@@ -810,10 +810,10 @@ var formatBalanceLabel = (remainingMinutes, balanceUnit) => {
   const totalMins = Math.round(remainingMinutes);
   const hours = Math.floor(totalMins / 60);
   const mins = totalMins % 60;
-  return {
-    text: hours > 0 ? `${hours}u ${mins}m` : `${mins}m`,
-    icon: "mdi:clock-outline"
-  };
+  const h3 = localize2("unit.hours");
+  const m3 = localize2("unit.minutes");
+  const text = hours > 0 && mins > 0 ? `${hours}${h3} ${mins}${m3}` : hours > 0 ? `${hours}${h3}` : `${mins}${m3}`;
+  return { text, icon: "mdi:progress-clock" };
 };
 
 // src/ui.ts
@@ -1085,10 +1085,11 @@ var renderFavoriteActionRow = (params) => {
         ${showBalance ? (() => {
     const { text, icon } = formatBalanceLabel(
       params.remainingMinutes,
-      params.balanceUnit
+      params.balanceUnit,
+      params.localize
     );
     return b2`
-                <ha-badge .label=${text}>
+                <ha-badge class="balance-badge" .label=${text}>
                   <ha-icon slot="icon" icon=${icon}></ha-icon>
                 </ha-badge>
               `;
@@ -2455,6 +2456,9 @@ CityVisitorParkingNewReservationCard.styles = [
       }
       .favorite-actions .badge-checked {
         --badge-color: var(--primary-color);
+      }
+      .favorite-actions .balance-badge {
+        --ha-font-size-xs: var(--ha-font-size-s);
       }
       .start-button {
         margin-left: auto;

--- a/custom_components/city_visitor_parking/frontend/dist/city-visitor-parking-card.js
+++ b/custom_components/city_visitor_parking/frontend/dist/city-visitor-parking-card.js
@@ -2120,7 +2120,7 @@ var CityVisitorParkingNewReservationCard = class extends BaseLocalizedCard {
       kind,
       start: kind ? str(payload?.window_start) : null,
       end: kind ? str(payload?.window_end) : null,
-      remainingMinutes: num(payload?.remaining_minutes),
+      remainingMinutes: num(payload?.remaining_balance),
       balanceUnit: str(payload?.balance_unit)
     };
   }

--- a/custom_components/city_visitor_parking/frontend/dist/translations/en.json
+++ b/custom_components/city_visitor_parking/frontend/dist/translations/en.json
@@ -78,5 +78,7 @@
   "message.reservation_update_failed": "We could not update your reservation.",
   "message.reservation_ended": "Your reservation was ended.",
   "message.reservation_end_failed": "We could not end your reservation.",
-  "placeholder.license_plate": "AA-123-B"
+  "placeholder.license_plate": "AA-123-B",
+  "unit.hours": "h",
+  "unit.minutes": "min"
 }

--- a/custom_components/city_visitor_parking/frontend/dist/translations/nl.json
+++ b/custom_components/city_visitor_parking/frontend/dist/translations/nl.json
@@ -78,5 +78,7 @@
   "message.reservation_update_failed": "We kunnen je reservering niet bijwerken.",
   "message.reservation_ended": "Je reservering is beëindigd.",
   "message.reservation_end_failed": "We kunnen je reservering niet beëindigen.",
-  "placeholder.license_plate": "AA-123-B"
+  "placeholder.license_plate": "AA-123-B",
+  "unit.hours": "u",
+  "unit.minutes": "m"
 }

--- a/custom_components/city_visitor_parking/frontend/src/card-parking.ts
+++ b/custom_components/city_visitor_parking/frontend/src/card-parking.ts
@@ -110,6 +110,9 @@ class CityVisitorParkingNewReservationCard extends BaseLocalizedCard<CardConfig>
       .favorite-actions .badge-checked {
         --badge-color: var(--primary-color);
       }
+      .favorite-actions .balance-badge {
+        --ha-font-size-xs: var(--ha-font-size-s);
+      }
       .start-button {
         margin-left: auto;
       }

--- a/custom_components/city_visitor_parking/frontend/src/card-parking.ts
+++ b/custom_components/city_visitor_parking/frontend/src/card-parking.ts
@@ -999,7 +999,7 @@ class CityVisitorParkingNewReservationCard extends BaseLocalizedCard<CardConfig>
       kind,
       start: kind ? str(payload?.window_start) : null,
       end: kind ? str(payload?.window_end) : null,
-      remainingMinutes: num(payload?.remaining_minutes),
+      remainingMinutes: num(payload?.remaining_balance),
       balanceUnit: str(payload?.balance_unit),
     };
   }

--- a/custom_components/city_visitor_parking/frontend/src/helpers.ts
+++ b/custom_components/city_visitor_parking/frontend/src/helpers.ts
@@ -271,6 +271,7 @@ export const isHassRunning = (
 export const formatBalanceLabel = (
   remainingMinutes: number,
   balanceUnit: string | null,
+  localize: (key: string) => string,
 ): { text: string; icon: string } => {
   const isMonetary =
     balanceUnit !== null && balanceUnit !== "TIMES" && balanceUnit !== "MINUTE";
@@ -296,8 +297,13 @@ export const formatBalanceLabel = (
   const totalMins = Math.round(remainingMinutes);
   const hours = Math.floor(totalMins / 60);
   const mins = totalMins % 60;
-  return {
-    text: hours > 0 ? `${hours}u ${mins}m` : `${mins}m`,
-    icon: "mdi:clock-outline",
-  };
+  const h = localize("unit.hours");
+  const m = localize("unit.minutes");
+  const text =
+    hours > 0 && mins > 0
+      ? `${hours}${h} ${mins}${m}`
+      : hours > 0
+        ? `${hours}${h}`
+        : `${mins}${m}`;
+  return { text, icon: "mdi:progress-clock" };
 };

--- a/custom_components/city_visitor_parking/frontend/src/translations/en.json
+++ b/custom_components/city_visitor_parking/frontend/src/translations/en.json
@@ -78,5 +78,7 @@
   "message.reservation_update_failed": "We could not update your reservation.",
   "message.reservation_ended": "Your reservation was ended.",
   "message.reservation_end_failed": "We could not end your reservation.",
-  "placeholder.license_plate": "AA-123-B"
+  "placeholder.license_plate": "AA-123-B",
+  "unit.hours": "h",
+  "unit.minutes": "min"
 }

--- a/custom_components/city_visitor_parking/frontend/src/translations/nl.json
+++ b/custom_components/city_visitor_parking/frontend/src/translations/nl.json
@@ -78,5 +78,7 @@
   "message.reservation_update_failed": "We kunnen je reservering niet bijwerken.",
   "message.reservation_ended": "Je reservering is beëindigd.",
   "message.reservation_end_failed": "We kunnen je reservering niet beëindigen.",
-  "placeholder.license_plate": "AA-123-B"
+  "placeholder.license_plate": "AA-123-B",
+  "unit.hours": "u",
+  "unit.minutes": "m"
 }

--- a/custom_components/city_visitor_parking/frontend/src/types.ts
+++ b/custom_components/city_visitor_parking/frontend/src/types.ts
@@ -116,10 +116,10 @@ export type ZoneStatusResponse = {
   window_end: string | null;
 
   /**
-   * Non-negative remaining permit balance in minutes.
+   * Non-negative remaining permit balance.
    * `build_status_payload()` clamps this value to `0` or higher.
    */
-  remaining_minutes: number;
+  remaining_balance: number;
 
   /**
    * Permit balance unit from coordinator data, or `null` when the provider

--- a/custom_components/city_visitor_parking/frontend/src/ui.ts
+++ b/custom_components/city_visitor_parking/frontend/src/ui.ts
@@ -395,9 +395,10 @@ export const renderFavoriteActionRow = (params: {
               const { text, icon } = formatBalanceLabel(
                 params.remainingMinutes!,
                 params.balanceUnit,
+                params.localize,
               );
               return html`
-                <ha-badge .label=${text}>
+                <ha-badge class="balance-badge" .label=${text}>
                   <ha-icon slot="icon" icon=${icon}></ha-icon>
                 </ha-badge>
               `;

--- a/custom_components/city_visitor_parking/models.py
+++ b/custom_components/city_visitor_parking/models.py
@@ -61,7 +61,7 @@ class CoordinatorData:
     """Coordinator data for entities and services."""
 
     permit_id: str
-    permit_remaining_minutes: float
+    permit_remaining_balance: float
     permit_balance_unit: str | None
     zone_validity: tuple[TimeRange, ...]
     reservations: tuple[Reservation, ...]

--- a/custom_components/city_visitor_parking/payloads.py
+++ b/custom_components/city_visitor_parking/payloads.py
@@ -147,7 +147,7 @@ def build_status_payload(
         "provider_window_end": (
             utc_iso(provider_window.end) if provider_window else None
         ),
-        "remaining_minutes": max(0.0, data.permit_remaining_minutes),
+        "remaining_balance": max(0.0, data.permit_remaining_balance),
         "balance_unit": data.permit_balance_unit,
         "permit_id": data.permit_id,
     }

--- a/custom_components/city_visitor_parking/sensor.py
+++ b/custom_components/city_visitor_parking/sensor.py
@@ -89,7 +89,7 @@ class RemainingTimeSensor(CityVisitorParkingEntity):
     def _update_from_coordinator(self) -> None:
         """Update the sensor from coordinator data."""
         balance_unit = self.coordinator.data.permit_balance_unit
-        remaining_minutes = _remaining_balance_minutes(self.coordinator.data)
+        remaining_balance = _remaining_balance(self.coordinator.data)
         next_end_time = _next_end_time(self.coordinator.data)
         active_count = len(self.coordinator.data.active_reservations)
         attributes: dict[str, object] = dict(self._attr_extra_state_attributes or {})  # type: ignore[has-type]
@@ -105,13 +105,13 @@ class RemainingTimeSensor(CityVisitorParkingEntity):
             self._attr_device_class = SensorDeviceClass.MONETARY
             self._attr_native_unit_of_measurement = balance_unit
             self._attr_suggested_display_precision = 2
-            self._attr_native_value = float(remaining_minutes)
+            self._attr_native_value = float(remaining_balance)
         else:
             self._attr_device_class = None
             self._attr_native_unit_of_measurement = UnitOfTime.HOURS
             self._attr_suggested_display_precision = 2
-            attributes["remaining_minutes"] = remaining_minutes
-            self._attr_native_value = round(remaining_minutes / 60, 2)
+            attributes["remaining_balance"] = remaining_balance
+            self._attr_native_value = round(remaining_balance / 60, 2)
 
         self._attr_extra_state_attributes = attributes
 
@@ -247,9 +247,9 @@ class FavoritesSensor(CityVisitorParkingEntity):
         self._attr_native_value = len(self.coordinator.data.favorites)
 
 
-def _remaining_balance_minutes(data: CoordinatorData) -> float:
+def _remaining_balance(data: CoordinatorData) -> float:
     """Return the remaining balance (minutes, times, or monetary amount)."""
-    return max(0.0, data.permit_remaining_minutes)
+    return max(0.0, data.permit_remaining_balance)
 
 
 def _next_end_time(data: CoordinatorData) -> datetime | None:

--- a/custom_components/city_visitor_parking/sensor.py
+++ b/custom_components/city_visitor_parking/sensor.py
@@ -78,7 +78,7 @@ class FutureReservationsSensor(CityVisitorParkingEntity):
 
 
 class RemainingTimeSensor(CityVisitorParkingEntity):
-    """Sensor for remaining balance (time or monetary)."""
+    """Sensor for remaining balance presented by balance unit."""
 
     _entity_key = "remaining_time"
     _attr_translation_key: str | None = "remaining_time"
@@ -101,13 +101,22 @@ class RemainingTimeSensor(CityVisitorParkingEntity):
             }
         )
 
-        if balance_unit is not None and balance_unit not in {"TIMES", "MINUTE"}:
+        if balance_unit == "TIMES":
+            self._attr_device_class = None
+            self._attr_native_unit_of_measurement = "times"
+            self._attr_suggested_display_precision = 0
+            attributes["remaining_balance"] = remaining_balance
+            self._attr_native_value = _as_count_value(remaining_balance)
+        elif balance_unit is not None and balance_unit != "MINUTE":
             self._attr_device_class = SensorDeviceClass.MONETARY
-            self._attr_native_unit_of_measurement = balance_unit
+            self._attr_native_unit_of_measurement = _normalize_currency_unit(
+                balance_unit
+            )
             self._attr_suggested_display_precision = 2
+            attributes["remaining_balance"] = remaining_balance
             self._attr_native_value = float(remaining_balance)
         else:
-            self._attr_device_class = None
+            self._attr_device_class = SensorDeviceClass.DURATION
             self._attr_native_unit_of_measurement = UnitOfTime.HOURS
             self._attr_suggested_display_precision = 2
             attributes["remaining_balance"] = remaining_balance
@@ -250,6 +259,20 @@ class FavoritesSensor(CityVisitorParkingEntity):
 def _remaining_balance(data: CoordinatorData) -> float:
     """Return the remaining balance (minutes, times, or monetary amount)."""
     return max(0.0, data.permit_remaining_balance)
+
+
+def _as_count_value(value: float) -> int | float:
+    """Return an integer count when the balance is a whole number."""
+    if value.is_integer():
+        return int(value)
+    return value
+
+
+def _normalize_currency_unit(unit: str) -> str:
+    """Normalize provider currency labels to Home Assistant-friendly codes."""
+    if unit == "EURO":
+        return "EUR"
+    return unit
 
 
 def _next_end_time(data: CoordinatorData) -> datetime | None:

--- a/tests/components/city_visitor_parking/test_coordinator.py
+++ b/tests/components/city_visitor_parking/test_coordinator.py
@@ -34,7 +34,7 @@ from custom_components.city_visitor_parking.coordinator import (
     _as_utc_datetime,
     _compute_zone_availability,
     _normalize_favorites,
-    _normalize_remaining_minutes,
+    _normalize_remaining_balance,
     _normalize_reservations,
     _normalize_zone_validity,
     _should_attempt_auto_end,
@@ -250,19 +250,19 @@ async def test_provider_protocol_raises() -> None:
 def test_normalize_helpers() -> None:
     """Normalization helpers should handle invalid input."""
     assert (
-        _normalize_remaining_minutes(cast("Permit", {"remaining_balance": None})) == 0
+        _normalize_remaining_balance(cast("Permit", {"remaining_balance": None})) == 0
     )
     assert (
-        _normalize_remaining_minutes(cast("Permit", {"remaining_balance": "bad"})) == 0
+        _normalize_remaining_balance(cast("Permit", {"remaining_balance": "bad"})) == 0
     )
     assert (
-        _normalize_remaining_minutes(cast("Permit", {"remaining_balance": "-5"})) == 0
+        _normalize_remaining_balance(cast("Permit", {"remaining_balance": "-5"})) == 0
     )
     assert (
-        _normalize_remaining_minutes(cast("Permit", {"remaining_balance": 15}))
+        _normalize_remaining_balance(cast("Permit", {"remaining_balance": 15}))
         == EXPECTED_MINUTES
     )
-    assert _normalize_remaining_minutes(cast("Permit", {"remaining_balance": []})) == 0
+    assert _normalize_remaining_balance(cast("Permit", {"remaining_balance": []})) == 0
 
     now = datetime(2025, 1, 1, 8, 0, tzinfo=UTC)
     validity = _normalize_zone_validity(
@@ -356,7 +356,7 @@ async def test_auto_end_skips_when_chargeable(hass: HomeAssistant) -> None:
 
     data = CoordinatorData(
         permit_id="permit",
-        permit_remaining_minutes=0,
+        permit_remaining_balance=0,
         permit_balance_unit=None,
         zone_validity=(),
         reservations=(),
@@ -395,7 +395,7 @@ async def test_auto_end_skips_without_reservations(hass: HomeAssistant) -> None:
 
     data = CoordinatorData(
         permit_id="permit",
-        permit_remaining_minutes=0,
+        permit_remaining_balance=0,
         permit_balance_unit=None,
         zone_validity=(),
         reservations=(),
@@ -752,7 +752,7 @@ def _idle_data(
     """Return a CoordinatorData instance representing a quiet, idle state."""
     return CoordinatorData(
         permit_id="permit",
-        permit_remaining_minutes=0,
+        permit_remaining_balance=0,
         permit_balance_unit=None,
         zone_validity=(),
         reservations=(),

--- a/tests/components/city_visitor_parking/test_diagnostics.py
+++ b/tests/components/city_visitor_parking/test_diagnostics.py
@@ -70,7 +70,7 @@ async def test_diagnostics_redacts_sensitive_data(hass: HomeAssistant) -> None:
     )
     data = CoordinatorData(
         permit_id="permit",
-        permit_remaining_minutes=30,
+        permit_remaining_balance=30,
         permit_balance_unit=None,
         zone_validity=(
             TimeRange(

--- a/tests/components/city_visitor_parking/test_entities.py
+++ b/tests/components/city_visitor_parking/test_entities.py
@@ -8,6 +8,8 @@ from typing import TYPE_CHECKING, cast
 from unittest.mock import AsyncMock, MagicMock
 
 from freezegun import freeze_time
+from homeassistant.components.sensor import SensorDeviceClass
+from homeassistant.const import UnitOfTime
 from homeassistant.util import dt as dt_util
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
@@ -52,6 +54,10 @@ if TYPE_CHECKING:
 
 EXPECTED_REMAINING_HOURS = 2.0
 EXPECTED_REMAINING_MINUTES = 90
+EXPECTED_COUNT_BALANCE = 3
+EXPECTED_DURATION_BALANCE = 120
+EXPECTED_MONETARY_BALANCE = 12.5
+EXPECTED_EURO_BALANCE = 237.5
 
 
 async def test_entity_unique_id_and_device_info() -> None:
@@ -294,12 +300,131 @@ async def test_sensors_handle_coordinator_update(
     assert active_sensor.native_value == 1
     assert future_sensor.native_value == 1
     assert remaining_sensor.native_value == EXPECTED_REMAINING_HOURS
+    assert remaining_sensor.device_class == SensorDeviceClass.DURATION
     assert availability_sensor.native_value == STATE_CHARGEABLE
     assert provider_start.native_value == zone_window.start
     assert provider_end.native_value == zone_window.end
     assert next_start.native_value == zone_window.start
     assert next_end.native_value == zone_window.end
     assert favorites_sensor.native_value == 1
+
+
+async def test_remaining_balance_sensor_uses_count_presentation() -> None:
+    """Count balances should not be converted to hours."""
+    coordinator = _make_coordinator(
+        CoordinatorData(
+            permit_id="permit",
+            permit_remaining_balance=EXPECTED_COUNT_BALANCE,
+            permit_balance_unit="TIMES",
+            zone_validity=(),
+            reservations=(),
+            favorites=(),
+            zone_availability=ZoneAvailability(
+                is_chargeable_now=True,
+                next_change_time=None,
+                windows_today=(),
+            ),
+            active_reservations=(),
+        )
+    )
+    entry = _create_entry("provider:permit1:city")
+
+    sensor = RemainingTimeSensor(coordinator, entry)
+
+    assert sensor.native_value == EXPECTED_COUNT_BALANCE
+    assert sensor.native_unit_of_measurement == "times"
+    assert sensor.device_class is None
+    assert sensor.extra_state_attributes is not None
+    assert sensor.extra_state_attributes["remaining_balance"] == EXPECTED_COUNT_BALANCE
+
+
+async def test_remaining_balance_sensor_uses_duration_presentation() -> None:
+    """Minute balances should be presented as a duration."""
+    coordinator = _make_coordinator(
+        CoordinatorData(
+            permit_id="permit",
+            permit_remaining_balance=EXPECTED_DURATION_BALANCE,
+            permit_balance_unit="MINUTE",
+            zone_validity=(),
+            reservations=(),
+            favorites=(),
+            zone_availability=ZoneAvailability(
+                is_chargeable_now=True,
+                next_change_time=None,
+                windows_today=(),
+            ),
+            active_reservations=(),
+        )
+    )
+    entry = _create_entry("provider:permit1:city")
+
+    sensor = RemainingTimeSensor(coordinator, entry)
+
+    assert sensor.native_value == EXPECTED_REMAINING_HOURS
+    assert sensor.native_unit_of_measurement == UnitOfTime.HOURS
+    assert sensor.device_class == SensorDeviceClass.DURATION
+    assert sensor.extra_state_attributes is not None
+    assert (
+        sensor.extra_state_attributes["remaining_balance"] == EXPECTED_DURATION_BALANCE
+    )
+
+
+async def test_remaining_balance_sensor_uses_monetary_presentation() -> None:
+    """Monetary balances should keep their provider currency unit."""
+    coordinator = _make_coordinator(
+        CoordinatorData(
+            permit_id="permit",
+            permit_remaining_balance=EXPECTED_MONETARY_BALANCE,
+            permit_balance_unit="EUR",
+            zone_validity=(),
+            reservations=(),
+            favorites=(),
+            zone_availability=ZoneAvailability(
+                is_chargeable_now=True,
+                next_change_time=None,
+                windows_today=(),
+            ),
+            active_reservations=(),
+        )
+    )
+    entry = _create_entry("provider:permit1:city")
+
+    sensor = RemainingTimeSensor(coordinator, entry)
+
+    assert sensor.native_value == EXPECTED_MONETARY_BALANCE
+    assert sensor.native_unit_of_measurement == "EUR"
+    assert sensor.device_class == SensorDeviceClass.MONETARY
+    assert sensor.extra_state_attributes is not None
+    assert (
+        sensor.extra_state_attributes["remaining_balance"] == EXPECTED_MONETARY_BALANCE
+    )
+
+
+async def test_remaining_balance_sensor_normalizes_euro_currency_code() -> None:
+    """Provider EURO labels should be normalized to EUR for display."""
+    coordinator = _make_coordinator(
+        CoordinatorData(
+            permit_id="permit",
+            permit_remaining_balance=EXPECTED_EURO_BALANCE,
+            permit_balance_unit="EURO",
+            zone_validity=(),
+            reservations=(),
+            favorites=(),
+            zone_availability=ZoneAvailability(
+                is_chargeable_now=True,
+                next_change_time=None,
+                windows_today=(),
+            ),
+            active_reservations=(),
+        )
+    )
+    entry = _create_entry("provider:permit1:city")
+
+    sensor = RemainingTimeSensor(coordinator, entry)
+
+    assert sensor.native_value == EXPECTED_EURO_BALANCE
+    assert sensor.native_unit_of_measurement == "EUR"
+    assert sensor.device_class == SensorDeviceClass.MONETARY
 
 
 def _sample_data(zone_availability: ZoneAvailability | None = None) -> CoordinatorData:

--- a/tests/components/city_visitor_parking/test_entities.py
+++ b/tests/components/city_visitor_parking/test_entities.py
@@ -39,7 +39,7 @@ from custom_components.city_visitor_parking.sensor import (
     RemainingTimeSensor,
     _as_utc_iso,
     _next_end_time,
-    _remaining_balance_minutes,
+    _remaining_balance,
     _timerange_to_dict,
 )
 from custom_components.city_visitor_parking.time_windows import current_or_next_window
@@ -117,7 +117,7 @@ async def test_zone_availability_uses_overrides() -> None:
 
         data = CoordinatorData(
             permit_id="permit",
-            permit_remaining_minutes=0,
+            permit_remaining_balance=0,
             permit_balance_unit=None,
             zone_validity=tuple(zone_validity),
             reservations=(),
@@ -173,7 +173,7 @@ async def test_next_chargeable_window_uses_overrides() -> None:
         availability = _compute_zone_availability(zone_validity, options, now)
         data = CoordinatorData(
             permit_id="permit",
-            permit_remaining_minutes=0,
+            permit_remaining_balance=0,
             permit_balance_unit=None,
             zone_validity=tuple(zone_validity),
             reservations=(),
@@ -238,7 +238,7 @@ async def test_sensors_handle_coordinator_update(
     )
     data = CoordinatorData(
         permit_id="permit",
-        permit_remaining_minutes=120,
+        permit_remaining_balance=120,
         permit_balance_unit=None,
         zone_validity=(zone_window,),
         reservations=(
@@ -311,7 +311,7 @@ def _sample_data(zone_availability: ZoneAvailability | None = None) -> Coordinat
     )
     return CoordinatorData(
         permit_id="permit",
-        permit_remaining_minutes=90,
+        permit_remaining_balance=90,
         permit_balance_unit=None,
         zone_validity=(),
         reservations=(
@@ -353,7 +353,7 @@ def test_sensor_helpers() -> None:
     data = _sample_data()
     data_no_active = CoordinatorData(
         permit_id=data.permit_id,
-        permit_remaining_minutes=data.permit_remaining_minutes,
+        permit_remaining_balance=data.permit_remaining_balance,
         permit_balance_unit=None,
         zone_validity=data.zone_validity,
         reservations=data.reservations,
@@ -363,7 +363,7 @@ def test_sensor_helpers() -> None:
     )
     data_with_active = CoordinatorData(
         permit_id=data.permit_id,
-        permit_remaining_minutes=data.permit_remaining_minutes,
+        permit_remaining_balance=data.permit_remaining_balance,
         permit_balance_unit=None,
         zone_validity=data.zone_validity,
         reservations=data.reservations,
@@ -382,7 +382,7 @@ def test_sensor_helpers() -> None:
             ),
         ),
     )
-    assert _remaining_balance_minutes(data) == EXPECTED_REMAINING_MINUTES
+    assert _remaining_balance(data) == EXPECTED_REMAINING_MINUTES
     assert _next_end_time(data_no_active) is None
     assert _next_end_time(data_with_active) == datetime(2025, 1, 1, 7, 30, tzinfo=UTC)
     assert _as_utc_iso(None) == ""

--- a/tests/components/city_visitor_parking/test_payloads.py
+++ b/tests/components/city_visitor_parking/test_payloads.py
@@ -17,7 +17,7 @@ ZONE_STATUS_RESPONSE_KEYS = {
     "window_kind",
     "window_start",
     "window_end",
-    "remaining_minutes",
+    "remaining_balance",
     "balance_unit",
 }
 EXPECTED_REMAINING_MINUTES = 15
@@ -32,7 +32,7 @@ def test_build_status_payload_includes_zone_status_response_contract() -> None:
     )
     data = CoordinatorData(
         permit_id="permit-1",
-        permit_remaining_minutes=-12,
+        permit_remaining_balance=-12,
         permit_balance_unit="minutes",
         zone_validity=(current_window,),
         reservations=(),
@@ -53,7 +53,7 @@ def test_build_status_payload_includes_zone_status_response_contract() -> None:
     assert payload["window_kind"] == "current"
     assert payload["window_start"] == current_window.start.isoformat()
     assert payload["window_end"] == current_window.end.isoformat()
-    assert payload["remaining_minutes"] == 0.0
+    assert payload["remaining_balance"] == 0.0
     assert payload["balance_unit"] == "minutes"
 
 
@@ -63,7 +63,7 @@ def test_build_status_payload_uses_null_window_fields_when_no_window_applies() -
     next_change = now + timedelta(hours=2)
     data = CoordinatorData(
         permit_id="permit-1",
-        permit_remaining_minutes=15,
+        permit_remaining_balance=15,
         permit_balance_unit=None,
         zone_validity=(),
         reservations=(),
@@ -82,5 +82,5 @@ def test_build_status_payload_uses_null_window_fields_when_no_window_applies() -
     assert payload["window_kind"] is None
     assert payload["window_start"] is None
     assert payload["window_end"] is None
-    assert payload["remaining_minutes"] == EXPECTED_REMAINING_MINUTES
+    assert payload["remaining_balance"] == EXPECTED_REMAINING_MINUTES
     assert payload["balance_unit"] is None

--- a/tests/components/city_visitor_parking/test_services.py
+++ b/tests/components/city_visitor_parking/test_services.py
@@ -934,7 +934,7 @@ async def test_service_list_reservations_response(
     )
     data = CoordinatorData(
         permit_id="permit1",
-        permit_remaining_minutes=0,
+        permit_remaining_balance=0,
         permit_balance_unit=None,
         zone_validity=(),
         reservations=(active_reservation, future_reservation, past_reservation),
@@ -986,7 +986,7 @@ async def test_service_list_reservations_stale(hass: HomeAssistant) -> None:
     now = datetime(2025, 1, 1, 12, 0, tzinfo=UTC)
     data = CoordinatorData(
         permit_id="permit1",
-        permit_remaining_minutes=0,
+        permit_remaining_balance=0,
         permit_balance_unit=None,
         zone_validity=(),
         reservations=(
@@ -1044,7 +1044,7 @@ async def test_service_get_status_response(hass: HomeAssistant) -> None:
     effective_range = _override_range_for_day(now, time(11, 0), time(12, 0))
     entry.runtime_data.coordinator.data = CoordinatorData(
         permit_id="permit1",
-        permit_remaining_minutes=90,
+        permit_remaining_balance=90,
         permit_balance_unit=None,
         zone_validity=(provider_range,),
         reservations=(),
@@ -1072,7 +1072,7 @@ async def test_service_get_status_response(hass: HomeAssistant) -> None:
     assert response["is_chargeable_now"] is False
     assert response["window_kind"] == "next"
     assert response["permit_id"] == "permit1"
-    assert response["remaining_minutes"] == EXPECTED_REMAINING_MINUTES
+    assert response["remaining_balance"] == EXPECTED_REMAINING_MINUTES
     assert response["stale"] is False
     assert response["provider_windows_today"] == [
         {
@@ -1101,7 +1101,7 @@ async def test_service_get_status_stale(hass: HomeAssistant) -> None:
     )
     entry.runtime_data.coordinator.data = CoordinatorData(
         permit_id="permit1",
-        permit_remaining_minutes=30,
+        permit_remaining_balance=30,
         permit_balance_unit=None,
         zone_validity=(window,),
         reservations=(),
@@ -1157,7 +1157,7 @@ async def test_service_get_status_stale_recomputes_consistent_windows(
     )
     entry.runtime_data.coordinator.data = CoordinatorData(
         permit_id="permit1",
-        permit_remaining_minutes=45,
+        permit_remaining_balance=45,
         permit_balance_unit=None,
         zone_validity=(provider_range,),
         reservations=(),

--- a/tests/components/city_visitor_parking/test_websocket_api.py
+++ b/tests/components/city_visitor_parking/test_websocket_api.py
@@ -163,7 +163,7 @@ async def test_ws_get_status_current_window(hass: HomeAssistant) -> None:
     )
     data = CoordinatorData(
         permit_id="permit",
-        permit_remaining_minutes=0,
+        permit_remaining_balance=0,
         permit_balance_unit=None,
         zone_validity=(window,),
         reservations=(),
@@ -207,7 +207,7 @@ async def test_ws_get_status_next_window_override(hass: HomeAssistant) -> None:
     now = datetime(2025, 1, 6, 10, 0, tzinfo=UTC)
     data = CoordinatorData(
         permit_id="permit",
-        permit_remaining_minutes=0,
+        permit_remaining_balance=0,
         permit_balance_unit=None,
         zone_validity=(),
         reservations=(),


### PR DESCRIPTION
## Summary
- rename `CoordinatorData.permit_remaining_minutes` to `permit_remaining_balance`
- rename the status payload field from `remaining_minutes` to `remaining_balance`
- update the frontend contract, generated bundle, and affected tests to use the new name only

## Why
The field can represent minutes, counts, or monetary values depending on `permit_balance_unit`, so the old name incorrectly implied a minutes-only value.

## Impact
This is an intentional non-backward-compatible rename for the internal coordinator field and the frontend websocket payload contract.

## Validation
- local pre-commit hooks passed during `git commit`
- included checks: `ruff check`, `ruff format`, `codespell`, `prettier`, `mypy`, `pyright`, `pytest`, `frontend eslint`, `frontend prettier`, `frontend types`, `frontend test`, `frontend build`