### PR TITLE
ci: assign category labels from PR title instead of changed file paths

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,37 +1,12 @@
-documentation:
-  - changed-files:
-      - any-glob-to-any-file:
-          - "**/*.md"
-
 python:
   - changed-files:
       - any-glob-to-any-file:
           - "custom_components/**"
-
-enhancement:
-  - changed-files:
-      - any-glob-to-any-file:
-          - "custom_components/city_visitor_parking/frontend/**"
 
 frontend:
   - changed-files:
       - any-glob-to-any-file:
           - "custom_components/city_visitor_parking/frontend/**"
 
-tests:
-  - changed-files:
-      - any-glob-to-any-file:
-          - "tests/**"
-
 testing:
   - head-branch: ["testing"]
-
-ci:
-  - changed-files:
-      - any-glob-to-any-file:
-          - ".github/workflows/**"
-
-maintenance:
-  - changed-files:
-      - any-glob-to-any-file:
-          - ".github/**"

--- a/.github/workflows/conventional-label.yml
+++ b/.github/workflows/conventional-label.yml
@@ -37,7 +37,9 @@ jobs:
           CATEGORY_LABELS="breaking-change bugfix documentation enhancement refactor performance new-feature maintenance ci dependencies tests"
 
           case "$PR_TITLE" in
-            "feat!"*|feat"("*"!)"*)        LABEL="breaking-change" ;;
+            # Breaking change: any type ending with ! before the colon
+            # Matches feat!: ..., feat(scope)!: ..., fix!: ..., etc.
+            *"!:"*)                        LABEL="breaking-change" ;;
             "feat:"*|feat"("*"):"*)        LABEL="enhancement" ;;
             "fix:"*|fix"("*"):"*)          LABEL="bugfix" ;;
             "refactor:"*|refactor"("*"):"*) LABEL="refactor" ;;

--- a/.github/workflows/conventional-label.yml
+++ b/.github/workflows/conventional-label.yml
@@ -1,0 +1,68 @@
+---
+# Assigns exactly one release-category label based on the conventional commit
+# prefix in the PR title (e.g. "feat:" → enhancement, "fix:" → bugfix).
+# This replaces file-path-based assignment of category labels so that a PR
+# touching tests/, .github/, and *.md is not placed in every changelog section.
+name: Conventional commit label
+
+# yamllint disable-line rule:truthy
+on:
+  pull_request_target: # zizmor: ignore[dangerous-triggers] This workflow only assigns labels and does not check out or run PR code.
+    types:
+      - opened
+      - edited
+      - reopened
+      - synchronize
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  label:
+    name: Assign category label
+    runs-on: ubuntu-latest
+    steps:
+      - name: Assign label from conventional commit prefix
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          CATEGORY_LABELS="breaking-change bugfix documentation enhancement refactor performance new-feature maintenance ci dependencies tests"
+
+          case "$PR_TITLE" in
+            "feat!"*|feat"("*"!)"*)        LABEL="breaking-change" ;;
+            "feat:"*|feat"("*"):"*)        LABEL="enhancement" ;;
+            "fix:"*|fix"("*"):"*)          LABEL="bugfix" ;;
+            "refactor:"*|refactor"("*"):"*) LABEL="refactor" ;;
+            "perf:"*|perf"("*"):"*)        LABEL="performance" ;;
+            "test:"*|"tests:"*|test"("*"):"*) LABEL="tests" ;;
+            "docs:"*|"doc:"*|docs"("*"):"*) LABEL="documentation" ;;
+            "chore:"*|chore"("*"):"*)      LABEL="maintenance" ;;
+            "ci:"*|ci"("*"):"*)            LABEL="ci" ;;
+            "build:"*|build"("*"):"*)      LABEL="maintenance" ;;
+            "deps:"*|deps"("*"):"*)        LABEL="dependencies" ;;
+            *)                             LABEL="" ;;
+          esac
+
+          if [ -z "$LABEL" ]; then
+            echo "No conventional commit prefix recognised in: $PR_TITLE"
+            exit 0
+          fi
+
+          echo "Assigning label: $LABEL"
+
+          # Remove all other category labels that may have been set previously
+          for l in $CATEGORY_LABELS; do
+            if [ "$l" != "$LABEL" ]; then
+              gh pr edit "$PR_NUMBER" --repo "$REPO" --remove-label "$l" 2>/dev/null || true
+            fi
+          done
+
+          gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label "$LABEL"

--- a/.github/workflows/conventional-label.yml
+++ b/.github/workflows/conventional-label.yml
@@ -36,22 +36,26 @@ jobs:
         run: |
           CATEGORY_LABELS="breaking-change bugfix documentation enhancement refactor performance new-feature maintenance ci dependencies tests"
 
-          case "$PR_TITLE" in
-            # Breaking change: any type ending with ! before the colon
-            # Matches feat!: ..., feat(scope)!: ..., fix!: ..., etc.
-            *"!:"*)                        LABEL="breaking-change" ;;
-            "feat:"*|feat"("*"):"*)        LABEL="enhancement" ;;
-            "fix:"*|fix"("*"):"*)          LABEL="bugfix" ;;
-            "refactor:"*|refactor"("*"):"*) LABEL="refactor" ;;
-            "perf:"*|perf"("*"):"*)        LABEL="performance" ;;
-            "test:"*|"tests:"*|test"("*"):"*) LABEL="tests" ;;
-            "docs:"*|"doc:"*|docs"("*"):"*) LABEL="documentation" ;;
-            "chore:"*|chore"("*"):"*)      LABEL="maintenance" ;;
-            "ci:"*|ci"("*"):"*)            LABEL="ci" ;;
-            "build:"*|build"("*"):"*)      LABEL="maintenance" ;;
-            "deps:"*|deps"("*"):"*)        LABEL="dependencies" ;;
-            *)                             LABEL="" ;;
-          esac
+          # Breaking change: <type>[(<scope>)]!: anchored at the start of the title.
+          # Using grep rather than a case glob to avoid matching "!:" mid-title
+          # (e.g. "chore: explain the !: token" must not become breaking-change).
+          if echo "$PR_TITLE" | grep -qE '^[a-z]+(\([^)]+\))?!:'; then
+            LABEL="breaking-change"
+          else
+            case "$PR_TITLE" in
+              "feat:"*|feat"("*"):"*)        LABEL="enhancement" ;;
+              "fix:"*|fix"("*"):"*)          LABEL="bugfix" ;;
+              "refactor:"*|refactor"("*"):"*) LABEL="refactor" ;;
+              "perf:"*|perf"("*"):"*)        LABEL="performance" ;;
+              "test:"*|"tests:"*|test"("*"):"*|tests"("*"):"*) LABEL="tests" ;;
+              "docs:"*|"doc:"*|docs"("*"):"*|doc"("*"):"*) LABEL="documentation" ;;
+              "chore:"*|chore"("*"):"*)      LABEL="maintenance" ;;
+              "ci:"*|ci"("*"):"*)            LABEL="ci" ;;
+              "build:"*|build"("*"):"*)      LABEL="maintenance" ;;
+              "deps:"*|deps"("*"):"*)        LABEL="dependencies" ;;
+              *)                             LABEL="" ;;
+            esac
+          fi
 
           if [ -z "$LABEL" ]; then
             echo "No conventional commit prefix recognised in: $PR_TITLE"


### PR DESCRIPTION
## Summary

- File-path-based labeling caused PRs touching multiple areas (tests, workflows, docs) to appear in every changelog section simultaneously
- Removed `enhancement`, `maintenance`, `tests`, `documentation`, `ci` from `labeler.yml` (these were assigned based on which files changed)
- Added `conventional-label.yml` workflow that reads the conventional commit prefix from the PR title (`feat:`, `fix:`, `refactor:`, etc.) and assigns exactly one release category label, removing any conflicting ones

## Test plan
- [ ] Open a PR with title `feat: ...` → gets `enhancement` label only
- [ ] Open a PR touching both `tests/` and `.github/` → no longer appears in multiple changelog sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)