### PR TITLE
feat: enable demo mode via configuration.yaml

### DIFF
--- a/bak.frontend_files.yaml
+++ b/bak.frontend_files.yaml
@@ -1,2 +1,0 @@
-frontend:
-  - "custom_components/city_visitor_parking/frontend/**"

--- a/custom_components/city_visitor_parking/__init__.py
+++ b/custom_components/city_visitor_parking/__init__.py
@@ -25,6 +25,7 @@ from homeassistant.exceptions import (
     ConfigEntryError,
     ConfigEntryNotReady,
 )
+from homeassistant.helpers import config_validation as cv
 from homeassistant.setup import async_when_setup
 from pycityvisitorparking import AuthError, NetworkError
 from pycityvisitorparking.exceptions import PyCityVisitorParkingError
@@ -89,7 +90,7 @@ CONFIG_SCHEMA: Final = vol.Schema(
     {
         vol.Optional(DOMAIN): vol.Schema(
             {
-                vol.Optional(CONF_DEMO_MODE, default=False): bool,
+                vol.Optional(CONF_DEMO_MODE, default=False): cv.boolean,
             }
         )
     },
@@ -101,7 +102,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up the City visitor parking integration."""
     domain_config = config.get(DOMAIN) or {}
     hass.data.setdefault(DOMAIN, {})
-    hass.data[DOMAIN][CONF_DEMO_MODE] = bool(domain_config.get(CONF_DEMO_MODE, False))
+    hass.data[DOMAIN][CONF_DEMO_MODE] = domain_config.get(CONF_DEMO_MODE, False)
     ha_cvp_version, pycvp_version = await async_get_versions(hass)
     _LOGGER.debug(
         "%s",

--- a/custom_components/city_visitor_parking/__init__.py
+++ b/custom_components/city_visitor_parking/__init__.py
@@ -5,10 +5,11 @@ from __future__ import annotations
 import inspect
 import logging
 import time
-from collections.abc import Callable, Mapping
+from collections.abc import Mapping
 from pathlib import Path
 from typing import TYPE_CHECKING, Final, Protocol, cast
 
+import voluptuous as vol
 from homeassistant.components.http import StaticPathConfig
 from homeassistant.components.lovelace.const import CONF_RESOURCE_TYPE_WS, LOVELACE_DATA
 from homeassistant.components.lovelace.resources import ResourceStorageCollection
@@ -24,7 +25,6 @@ from homeassistant.exceptions import (
     ConfigEntryError,
     ConfigEntryNotReady,
 )
-from homeassistant.helpers import config_validation as cv
 from homeassistant.setup import async_when_setup
 from pycityvisitorparking import AuthError, NetworkError
 from pycityvisitorparking.exceptions import PyCityVisitorParkingError
@@ -33,6 +33,7 @@ from .client import async_create_client
 from .const import (
     CONF_API_URL,
     CONF_BASE_URL,
+    CONF_DEMO_MODE,
     CONF_FREE_DATES,
     CONF_GUI_URL,
     CONF_MUNICIPALITY,
@@ -60,16 +61,6 @@ if TYPE_CHECKING:
 _LOGGER = logging.getLogger(__name__)
 
 
-class _ConfigValidation(Protocol):
-    """Protocol for config validation helpers we rely on."""
-
-    def config_entry_only_config_schema(
-        self, domain: str
-    ) -> Callable[[ConfigType], ConfigType]:
-        """Return a config schema for config entry only integrations."""
-        raise NotImplementedError
-
-
 class _ResourceStorage(Protocol):
     """Protocol for Lovelace resource storage helpers we rely on."""
 
@@ -94,16 +85,23 @@ class _ResourceStorage(Protocol):
         raise NotImplementedError
 
 
-_config_entry_only_schema = cast(
-    "_ConfigValidation", cv
-).config_entry_only_config_schema
-CONFIG_SCHEMA: Final[Callable[[ConfigType], ConfigType]] = _config_entry_only_schema(
-    DOMAIN
+CONFIG_SCHEMA: Final = vol.Schema(
+    {
+        vol.Optional(DOMAIN): vol.Schema(
+            {
+                vol.Optional(CONF_DEMO_MODE, default=False): bool,
+            }
+        )
+    },
+    extra=vol.ALLOW_EXTRA,
 )
 
 
-async def async_setup(hass: HomeAssistant, _config: ConfigType) -> bool:
+async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up the City visitor parking integration."""
+    domain_config = config.get(DOMAIN) or {}
+    hass.data.setdefault(DOMAIN, {})
+    hass.data[DOMAIN][CONF_DEMO_MODE] = bool(domain_config.get(CONF_DEMO_MODE, False))
     ha_cvp_version, pycvp_version = await async_get_versions(hass)
     _LOGGER.debug(
         "%s",

--- a/custom_components/city_visitor_parking/config_flow.py
+++ b/custom_components/city_visitor_parking/config_flow.py
@@ -31,6 +31,7 @@ from .const import (
     CONF_API_URL,
     CONF_AUTO_END,
     CONF_BASE_URL,
+    CONF_DEMO_MODE,
     CONF_FREE_DATES,
     CONF_GUI_URL,
     CONF_MUNICIPALITY,
@@ -550,10 +551,11 @@ def _build_overrides(
 
 async def _async_load_providers(hass: HomeAssistant) -> dict[str, ProviderConfig]:
     """Load providers from the packaged YAML file."""
-    return await hass.async_add_executor_job(_load_providers_sync)
+    demo_mode: bool = hass.data.get(DOMAIN, {}).get(CONF_DEMO_MODE, False)
+    return await hass.async_add_executor_job(_load_providers_sync, demo_mode)
 
 
-def _load_providers_sync() -> dict[str, ProviderConfig]:
+def _load_providers_sync(demo_mode: bool = False) -> dict[str, ProviderConfig]:
     """Load provider definitions from disk in a worker thread."""
     with (
         resources.files(__package__)
@@ -564,8 +566,11 @@ def _load_providers_sync() -> dict[str, ProviderConfig]:
 
     providers: dict[str, ProviderConfig] = {}
     for key, config in data.items():
+        provider_id = str(config["provider_id"])
+        if provider_id == "demo" and not demo_mode:
+            continue
         providers[key] = ProviderConfig(
-            provider_id=str(config["provider_id"]),
+            provider_id=provider_id,
             municipality_name=str(config["municipality_name"]),
             base_url=_normalize_optional_text(config.get("base_url")),
             api_url=_normalize_optional_text(config.get("api_url")),

--- a/custom_components/city_visitor_parking/const.py
+++ b/custom_components/city_visitor_parking/const.py
@@ -11,6 +11,7 @@ DOMAIN: Final = "city_visitor_parking"
 
 PLATFORMS: Final[list[Platform]] = [Platform.SENSOR]
 
+CONF_DEMO_MODE: Final = "demo"
 CONF_PROVIDER_ID: Final = "provider_id"
 CONF_MUNICIPALITY: Final = "municipality_name"
 CONF_BASE_URL: Final = "base_url"

--- a/custom_components/city_visitor_parking/manifest.json
+++ b/custom_components/city_visitor_parking/manifest.json
@@ -10,6 +10,6 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/sir-Unknown/ha_City-Visitor-Parking/issues",
   "quality_scale": "platinum",
-  "requirements": ["pycityvisitorparking==0.5.23"],
+  "requirements": ["pycityvisitorparking==0.5.24"],
   "version": "0.0.0"
 }

--- a/custom_components/city_visitor_parking/providers.yaml
+++ b/custom_components/city_visitor_parking/providers.yaml
@@ -412,3 +412,21 @@ zwolle:
   base_url: "https://parkeerloket.zwolle.nl"
   gui_url: "https://parkeerloket.zwolle.nl/DVSPortal/"
   api_url: "/DVSWebAPI/api"
+
+#######################################################################
+# DEMO PROVIDERS
+# Requires `city_visitor_parking:\n  demo: true` in configuration.yaml.
+# No real credentials needed — returns fixed data for testing.
+#######################################################################
+
+den_haag_demo:
+  municipality_name: Den Haag Demo
+  provider_id: demo
+
+eindhoven_demo:
+  municipality_name: Eindhoven Demo
+  provider_id: demo
+
+groningen_demo:
+  municipality_name: Groningen Demo
+  provider_id: demo

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "ha-city-visitor-parking"
 version = "0.0.0"
 requires-python = ">=3.14.2"
-dependencies = ["pycityvisitorparking==0.5.23"]
+dependencies = ["pycityvisitorparking==0.5.24"]
 
 [dependency-groups]
 dev = [

--- a/uv.lock
+++ b/uv.lock
@@ -910,7 +910,7 @@ test = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "pycityvisitorparking", specifier = "==0.5.23" }]
+requires-dist = [{ name = "pycityvisitorparking", specifier = "==0.5.24" }]
 
 [package.metadata.requires-dev]
 dev = [
@@ -1670,14 +1670,14 @@ wheels = [
 
 [[package]]
 name = "pycityvisitorparking"
-version = "0.5.23"
+version = "0.5.24"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b4/30/e9e78f7b76cba16f97730fd56d480880025a89d373af1a6fae6d7b784608/pycityvisitorparking-0.5.23.tar.gz", hash = "sha256:be11d2d82d41fb60f8c3e66fb3a40a8ca80120692462a598f5dbe75c7c88da79", size = 69062, upload-time = "2026-04-13T21:57:15.693Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f0/14/560c3686141b5f1367d586c1238b2d624ec0c04cd54cc2e6ae05c6fd0190/pycityvisitorparking-0.5.24.tar.gz", hash = "sha256:0a4aeb201a239be2d1cf22fceeeb696c85a603f48485147292c81478e1963a73", size = 72480, upload-time = "2026-04-17T23:03:02.499Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ed/72/9b6db93d4cb63ea4ddb861c3860ad6e2f75bde0c346e9b88c238b138b545/pycityvisitorparking-0.5.23-py3-none-any.whl", hash = "sha256:40703578b40eb7bd1cc242fb373e314a7311ca4035424c5b732026e28ffa17e4", size = 66254, upload-time = "2026-04-13T21:57:13.879Z" },
+    { url = "https://files.pythonhosted.org/packages/33/c5/1d52a80fbdcf65e11228bb0a1ac32e49fd8ef06e605d846a96dad9c2016a/pycityvisitorparking-0.5.24-py3-none-any.whl", hash = "sha256:23852d7e5c50769b3ddc3fb2a5bdd65fbf3801c9372444f33f52c1be9d58ad62", size = 70017, upload-time = "2026-04-17T23:03:01.138Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Add a `configuration.yaml` option that makes demo providers visible in the integration setup flow:

```yaml
city_visitor_parking:
  demo: true
```

- Demo providers (Den Haag Demo, Eindhoven Demo, Groningen Demo) are hidden by default
- When `demo: true` is set, they appear in the municipality dropdown alongside real municipalities
- No real credentials required — the demo provider returns fixed data
- Supersedes #164

## How it works

- `CONFIG_SCHEMA` now accepts an optional `demo` boolean under the `city_visitor_parking` key (validated with `cv.boolean` so string values like `"false"` are handled correctly)
- `async_setup` stores the flag in `hass.data[DOMAIN]`
- `_async_load_providers` reads the flag and filters out providers with `provider_id: demo` unless it is set

## Commits

- `9b11009` feat: enable demo mode via configuration.yaml
- `acdb75a` fix: use cv.boolean for demo mode config validation
- `f0d0ae0` chore: remove bak.frontend_files.yaml
- `9500d3d` deps: bump pycityvisitorparking to 0.5.24

🤖 Generated with [Claude Code](https://claude.com/claude-code)