### PR TITLE
ci: enforce pycityvisitorparking version sync in manifest.json

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -130,20 +130,22 @@ jobs:
       - name: Check pycityvisitorparking version sync (manifest.json vs pyproject.toml)
         run: |
           python3 - <<'PYEOF'
-          import json, re, sys, pathlib
+          import json, tomllib, sys, pathlib
 
           manifest = json.loads(pathlib.Path("custom_components/city_visitor_parking/manifest.json").read_text())
-          pyproject = pathlib.Path("pyproject.toml").read_text()
+          with open("pyproject.toml", "rb") as f:
+              pyproject = tomllib.load(f)
 
           manifest_pkg = next((r for r in manifest["requirements"] if r.lower().startswith("pycityvisitorparking==")), None)
-          pyproject_match = re.search(r'(?i)pycityvisitorparking==(\S+)"', pyproject)
+          deps = pyproject.get("project", {}).get("dependencies", [])
+          pyproject_pkg = next((d for d in deps if d.lower().startswith("pycityvisitorparking==")), None)
 
-          if manifest_pkg is None or pyproject_match is None:
+          if manifest_pkg is None or pyproject_pkg is None:
               print("::warning::Non-PyPI pycityvisitorparking requirement — skipping sync check.")
               sys.exit(0)
 
           manifest_ver = manifest_pkg.split("==")[1]
-          pyproject_ver = pyproject_match.group(1)
+          pyproject_ver = pyproject_pkg.split("==")[1]
 
           print(f"manifest.json  : {manifest_ver}")
           print(f"pyproject.toml : {pyproject_ver}")

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -131,21 +131,42 @@ jobs:
         run: |
           python3 - <<'PYEOF'
           import json, tomllib, sys, pathlib
+          from packaging.requirements import Requirement
 
           manifest = json.loads(pathlib.Path("custom_components/city_visitor_parking/manifest.json").read_text())
           with open("pyproject.toml", "rb") as f:
               pyproject = tomllib.load(f)
 
-          manifest_pkg = next((r for r in manifest["requirements"] if r.lower().startswith("pycityvisitorparking==")), None)
-          deps = pyproject.get("project", {}).get("dependencies", [])
-          pyproject_pkg = next((d for d in deps if d.lower().startswith("pycityvisitorparking==")), None)
+          def find_pycvp(deps):
+              for d in deps:
+                  try:
+                      req = Requirement(d)
+                  except Exception:
+                      continue
+                  if req.name.lower() == "pycityvisitorparking":
+                      return req
+              return None
 
-          if manifest_pkg is None or pyproject_pkg is None:
+          manifest_req = find_pycvp(manifest["requirements"])
+          pyproject_req = find_pycvp(pyproject.get("project", {}).get("dependencies", []))
+
+          if manifest_req is None or pyproject_req is None:
+              print("::warning::pycityvisitorparking not found in requirements — skipping sync check.")
+              sys.exit(0)
+
+          if manifest_req.url or pyproject_req.url:
               print("::warning::Non-PyPI pycityvisitorparking requirement — skipping sync check.")
               sys.exit(0)
 
-          manifest_ver = manifest_pkg.split("==")[1]
-          pyproject_ver = pyproject_pkg.split("==")[1]
+          def eq_version(req, source):
+              versions = [s.version for s in req.specifier if s.operator == "=="]
+              if not versions:
+                  print(f"::error::{source}: pycityvisitorparking must use == pinning, got: {req}")
+                  sys.exit(1)
+              return versions[0]
+
+          manifest_ver = eq_version(manifest_req, "manifest.json")
+          pyproject_ver = eq_version(pyproject_req, "pyproject.toml")
 
           print(f"manifest.json  : {manifest_ver}")
           print(f"pyproject.toml : {pyproject_ver}")

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -127,6 +127,32 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Check pycityvisitorparking version sync (manifest.json vs pyproject.toml)
+        run: |
+          python3 - <<'PYEOF'
+          import json, re, sys, pathlib
+
+          manifest = json.loads(pathlib.Path("custom_components/city_visitor_parking/manifest.json").read_text())
+          pyproject = pathlib.Path("pyproject.toml").read_text()
+
+          manifest_pkg = next((r for r in manifest["requirements"] if r.lower().startswith("pycityvisitorparking==")), None)
+          pyproject_match = re.search(r'(?i)pycityvisitorparking==(\S+)"', pyproject)
+
+          if manifest_pkg is None or pyproject_match is None:
+              print("::warning::Non-PyPI pycityvisitorparking requirement — skipping sync check.")
+              sys.exit(0)
+
+          manifest_ver = manifest_pkg.split("==")[1]
+          pyproject_ver = pyproject_match.group(1)
+
+          print(f"manifest.json  : {manifest_ver}")
+          print(f"pyproject.toml : {pyproject_ver}")
+
+          if manifest_ver != pyproject_ver:
+              print(f"::error::pycityvisitorparking version mismatch: manifest.json={manifest_ver}, pyproject.toml={pyproject_ver}. Keep these in sync.")
+              sys.exit(1)
+          PYEOF
+
       - name: Check pycityvisitorparking version in manifest.json
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -162,7 +188,6 @@ jobs:
           echo "Latest on PyPI : $LATEST"
           echo "In manifest.json: $MANIFEST"
           if [ "$LATEST" != "$MANIFEST" ]; then
-            echo "::warning::manifest.json uses pycityvisitorparking==$MANIFEST but latest release is $LATEST."
             if [ -n "$PR_NUMBER" ]; then
               EXISTING=$(gh api "repos/$REPO/pulls/$PR_NUMBER/reviews" \
                 --jq '[.[] | select(.state == "CHANGES_REQUESTED" and .user.login == "github-actions[bot]")] | length')
@@ -174,6 +199,8 @@ jobs:
           Please update \`requirements\` in \`manifest.json\` before merging."
               fi
             fi
+            echo "::error::manifest.json uses pycityvisitorparking==$MANIFEST but latest release on PyPI is $LATEST."
+            exit 1
           else
             if [ -n "$PR_NUMBER" ]; then
               gh api "repos/$REPO/pulls/$PR_NUMBER/reviews" \


### PR DESCRIPTION
## Summary

- Adds a hard-fail CI check that `manifest.json` and `pyproject.toml` pin the same `pycityvisitorparking` version — blocks Dependabot PRs that forget to update `manifest.json`
- Promotes the existing PyPI latest check from a `::warning::` to a hard fail (`exit 1`)

## Test plan

- [ ] Open a PR where `pyproject.toml` and `manifest.json` have different versions → `manifest-version` job should fail
- [ ] Open a PR where both are in sync but behind PyPI latest → `manifest-version` job should fail
- [ ] Open a PR where both are in sync and on PyPI latest → `manifest-version` job should pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)