### PR TITLE
ci: improve release notes templates across all release types

### DIFF
--- a/.github/release-drafter-beta.yml
+++ b/.github/release-drafter-beta.yml
@@ -7,9 +7,27 @@ exclude-labels:
   - "skip-changelog"
   - "duplicate"
   - "invalid"
+exclude-contributors:
+  - "sir-Unknown"
+  - "dependabot[bot]"
+  - "renovate[bot]"
+  - "github-actions[bot]"
+  - "codex[bot]"
+  - "claude[bot]"
 sort-direction: ascending
 include-paths:
   - "custom_components/"
+autolabeler:
+  - label: "documentation"
+    files:
+      - "**/*.md"
+      - "blueprints/**"
+  - label: "tests"
+    files:
+      - "tests/**"
+  - label: "maintenance"
+    files:
+      - ".github/**"
 categories:
   - title: "🚨 Breaking changes"
     labels:
@@ -39,10 +57,27 @@ categories:
     labels:
       - "documentation"
 template: |
+  This integration is free and open source. If it saves you a trip to the parking portal, a beer is always appreciated! 🍺 <iframe src="https://github.com/sponsors/sir-Unknown/button" title="Sponsor sir-Unknown" height="32" width="114" style="border: 0; border-radius: 6px;"></iframe>
+
+  _Beheer bezoekersparkeervergunningen van [Nederlandse gemeenten](https://github.com/sir-Unknown/ha_City-Visitor-Parking#supported-municipalities) vanuit Home Assistant. [Nederlandse documentatie](https://github.com/sir-Unknown/ha_City-Visitor-Parking/wiki/nl/Home)._
+
+  _Manage Dutch municipality visitor parking permits directly from Home Assistant. This integration lets you start, update, and end visitor parking sessions without having to open the municipal parking portal. Keep your favorite license plates at hand, see at a glance whether parking is paid or free, and automate your visitor parking with Home Assistant automations and scripts._
+
+  _The integration supports a growing number of [Dutch municipalities](https://github.com/sir-Unknown/ha_City-Visitor-Parking#supported-municipalities) and connects to their parking systems. Is your municipality not listed? You can request support or contribute — for more information: [EN](https://github.com/sir-Unknown/ha_City-Visitor-Parking/wiki/en/add-municipalities) | [NL](https://github.com/sir-Unknown/ha_City-Visitor-Parking/wiki/nl/gemeenten-toevoegen)_
+
+  > [!IMPORTANT]
+  > This integration is under active development — thank you for using it and for your patience! Features may occasionally break, and new versions can sometimes introduce regressions. It is possible that a parking session is not correctly started, updated, or ended.
+  >
+  > Please always verify that your session is active through the official parking portal. The maintainer and all contributors cannot be held responsible for incorrectly registered visitor parking sessions or any fines that may result.
+  >
+  > This integration is built almost entirely with the help of AI agents, primarily ChatGPT and Claude.
+
   > [!WARNING]
   > **This is a beta pre-release.**
   > It may contain incomplete features or minor regressions.
   > **Use with caution in production Home Assistant environments.**
+
+  ---
 
   ## 🔗 pyCityVisitorParking
 
@@ -55,6 +90,10 @@ template: |
 
   $CHANGES
 
+  ## 👥 Contributors
+
+  $CONTRIBUTORS
+
   ## 📦 Installation
 
   In HACS, go to **City Visitor Parking** → **⋮** → **Redownload** → select this version from the version dropdown.
@@ -63,6 +102,23 @@ template: |
 
   If something breaks, reinstall the latest stable release the same way: **HACS** → **City Visitor Parking** → **⋮** → **Redownload** → select the stable version.
 
+  ## 📚 Documentation
+
+  See the [Wiki](https://github.com/sir-Unknown/ha_City-Visitor-Parking/wiki) for setup instructions and configuration options.
+
+  - [Installation](https://github.com/sir-Unknown/ha_City-Visitor-Parking/wiki/en/Installation)
+  - [Configuration](https://github.com/sir-Unknown/ha_City-Visitor-Parking/wiki/en/Configuration)
+  - [Lovelace cards](https://github.com/sir-Unknown/ha_City-Visitor-Parking/wiki/en/Lovelace-Cards)
+  - [Services](https://github.com/sir-Unknown/ha_City-Visitor-Parking/wiki/en/Services)
+  - [Blueprints](https://github.com/sir-Unknown/ha_City-Visitor-Parking/wiki/en/Blueprints)
+  - [Troubleshooting](https://github.com/sir-Unknown/ha_City-Visitor-Parking/wiki/en/Troubleshooting)
+
   ## 🐛 Reporting issues
 
+  Before opening an issue, download the diagnostics file via **Settings** → **Devices & services** → **City Visitor Parking** → **⋮** → **Download diagnostics**, and attach it to your report.
+
   [![Open an issue](https://img.shields.io/badge/Report%20a%20bug-red?logo=github)](https://github.com/sir-Unknown/ha_City-Visitor-Parking/issues/new)
+
+  Include the release version, a description of the problem, relevant logs, and the diagnostics file if available.
+
+  [![Full changelog](https://img.shields.io/badge/Full%20changelog-blue?logo=github)](https://github.com/sir-Unknown/ha_City-Visitor-Parking/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION)

--- a/.github/release-drafter-testing.yml
+++ b/.github/release-drafter-testing.yml
@@ -7,6 +7,13 @@ exclude-labels:
   - "skip-changelog"
   - "duplicate"
   - "invalid"
+exclude-contributors:
+  - "sir-Unknown"
+  - "dependabot[bot]"
+  - "renovate[bot]"
+  - "github-actions[bot]"
+  - "codex[bot]"
+  - "claude[bot]"
 sort-direction: ascending
 include-paths:
   - "custom_components/"
@@ -42,6 +49,7 @@ autolabeler:
   - label: "documentation"
     files:
       - "**/*.md"
+      - "blueprints/**"
   - label: "tests"
     files:
       - "tests/**"
@@ -49,11 +57,28 @@ autolabeler:
     files:
       - ".github/**"
 template: |
+  This integration is free and open source. If it saves you a trip to the parking portal, a beer is always appreciated! 🍺 <iframe src="https://github.com/sponsors/sir-Unknown/button" title="Sponsor sir-Unknown" height="32" width="114" style="border: 0; border-radius: 6px;"></iframe>
+
+  _Beheer bezoekersparkeervergunningen van [Nederlandse gemeenten](https://github.com/sir-Unknown/ha_City-Visitor-Parking#supported-municipalities) vanuit Home Assistant. [Nederlandse documentatie](https://github.com/sir-Unknown/ha_City-Visitor-Parking/wiki/nl/Home)._
+
+  _Manage Dutch municipality visitor parking permits directly from Home Assistant. This integration lets you start, update, and end visitor parking sessions without having to open the municipal parking portal. Keep your favorite license plates at hand, see at a glance whether parking is paid or free, and automate your visitor parking with Home Assistant automations and scripts._
+
+  _The integration supports a growing number of [Dutch municipalities](https://github.com/sir-Unknown/ha_City-Visitor-Parking#supported-municipalities) and connects to their parking systems. Is your municipality not listed? You can request support or contribute — for more information: [EN](https://github.com/sir-Unknown/ha_City-Visitor-Parking/wiki/en/add-municipalities) | [NL](https://github.com/sir-Unknown/ha_City-Visitor-Parking/wiki/nl/gemeenten-toevoegen)_
+
+  > [!IMPORTANT]
+  > This integration is under active development — thank you for using it and for your patience! Features may occasionally break, and new versions can sometimes introduce regressions. It is possible that a parking session is not correctly started, updated, or ended.
+  >
+  > Please always verify that your session is active through the official parking portal. The maintainer and all contributors cannot be held responsible for incorrectly registered visitor parking sessions or any fines that may result.
+  >
+  > This integration is built almost entirely with the help of AI agents, primarily ChatGPT and Claude.
+
   > [!WARNING]
   > **This is a testing release and is highly unstable.**
   > It may contain breaking changes, incomplete features, or regressions.
   > **Only install this if you were explicitly asked to by the maintainer.**
   > Do not use this in a production Home Assistant environment.
+
+  ---
 
   ## 🔗 pyCityVisitorParking
 
@@ -64,6 +89,10 @@ template: |
   ## 📋 Changes
 
   $CHANGES
+
+  ## 👥 Contributors
+
+  $CONTRIBUTORS
 
   ## 📦 Installation
 
@@ -86,6 +115,17 @@ template: |
       pycityvisitorparking.provider.dvsportal_new: debug
   ```
 
+  ## 📚 Documentation
+
+  See the [Wiki](https://github.com/sir-Unknown/ha_City-Visitor-Parking/wiki) for setup instructions and configuration options.
+
+  - [Installation](https://github.com/sir-Unknown/ha_City-Visitor-Parking/wiki/en/Installation)
+  - [Configuration](https://github.com/sir-Unknown/ha_City-Visitor-Parking/wiki/en/Configuration)
+  - [Lovelace cards](https://github.com/sir-Unknown/ha_City-Visitor-Parking/wiki/en/Lovelace-Cards)
+  - [Services](https://github.com/sir-Unknown/ha_City-Visitor-Parking/wiki/en/Services)
+  - [Blueprints](https://github.com/sir-Unknown/ha_City-Visitor-Parking/wiki/en/Blueprints)
+  - [Troubleshooting](https://github.com/sir-Unknown/ha_City-Visitor-Parking/wiki/en/Troubleshooting)
+
   ## 🐛 Reporting issues
 
   Before opening an issue, download the diagnostics file via **Settings** → **Devices & services** → **City Visitor Parking** → **⋮** → **Download diagnostics**, and attach it to your report.
@@ -93,3 +133,5 @@ template: |
   [![Open an issue](https://img.shields.io/badge/Report%20a%20bug-red?logo=github)](https://github.com/sir-Unknown/ha_City-Visitor-Parking/issues/new)
 
   Include the release version, a description of the problem, relevant logs, and the diagnostics file if available.
+
+  [![Full changelog](https://img.shields.io/badge/Full%20changelog-blue?logo=github)](https://github.com/sir-Unknown/ha_City-Visitor-Parking/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION)

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -7,9 +7,27 @@ exclude-labels:
   - "skip-changelog"
   - "duplicate"
   - "invalid"
+exclude-contributors:
+  - "sir-Unknown"
+  - "dependabot[bot]"
+  - "renovate[bot]"
+  - "github-actions[bot]"
+  - "codex[bot]"
+  - "claude[bot]"
 sort-direction: ascending
 include-paths:
   - "custom_components/"
+autolabeler:
+  - label: "documentation"
+    files:
+      - "**/*.md"
+      - "blueprints/**"
+  - label: "tests"
+    files:
+      - "tests/**"
+  - label: "maintenance"
+    files:
+      - ".github/**"
 categories:
   - title: "🚨 Breaking changes"
     labels:
@@ -60,24 +78,48 @@ version-resolver:
       - "tests"
   default: patch
 template: |
-  🚗 City Visitor Parking is a Home Assistant integration that lets you register visitor parking permits directly from your dashboard.
+  This integration is free and open source. If it saves you a trip to the parking portal, a beer is always appreciated! 🍺 <iframe src="https://github.com/sponsors/sir-Unknown/button" title="Sponsor sir-Unknown" height="32" width="114" style="border: 0; border-radius: 6px;"></iframe>
+
+  _Beheer bezoekersparkeervergunningen van [Nederlandse gemeenten](https://github.com/sir-Unknown/ha_City-Visitor-Parking#supported-municipalities) vanuit Home Assistant. [Nederlandse documentatie](https://github.com/sir-Unknown/ha_City-Visitor-Parking/wiki/nl/Home)._
+
+  _Manage Dutch municipality visitor parking permits directly from Home Assistant. This integration lets you start, update, and end visitor parking sessions without having to open the municipal parking portal. Keep your favorite license plates at hand, see at a glance whether parking is paid or free, and automate your visitor parking with Home Assistant automations and scripts._
+
+  _The integration supports a growing number of [Dutch municipalities](https://github.com/sir-Unknown/ha_City-Visitor-Parking#supported-municipalities) and connects to their parking systems. Is your municipality not listed? You can request support or contribute — for more information: [EN](https://github.com/sir-Unknown/ha_City-Visitor-Parking/wiki/en/add-municipalities) | [NL](https://github.com/sir-Unknown/ha_City-Visitor-Parking/wiki/nl/gemeenten-toevoegen)_
+
+  > [!IMPORTANT]
+  > This integration is under active development — thank you for using it and for your patience! Features may occasionally break, and new versions can sometimes introduce regressions. It is possible that a parking session is not correctly started, updated, or ended.
+  >
+  > Please always verify that your session is active through the official parking portal. The maintainer and all contributors cannot be held responsible for incorrectly registered visitor parking sessions or any fines that may result.
+  >
+  > This integration is built almost entirely with the help of AI agents, primarily ChatGPT and Claude.
+
+  ---
 
   ## 📋 Changes
 
   $CHANGES
 
+  ## 👥 Contributors
+
+  $CONTRIBUTORS
+
   ## 🔗 pyCityVisitorParking
 
   Built with [pyCityVisitorParking](https://github.com/sir-Unknown/pyCityVisitorParking) library version: PYCVP_VERSION_PLACEHOLDER
 
-  ## 📦 Installation
-
-  [![Open in HACS](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=sir-Unknown&repository=ha_City-Visitor-Parking&category=integration)
-
   ## 📚 Documentation
 
-  See the [README](https://github.com/sir-Unknown/ha_City-Visitor-Parking#readme) for setup instructions and configuration options.
+  See the [Wiki](https://github.com/sir-Unknown/ha_City-Visitor-Parking/wiki) for setup instructions and configuration options.
+
+  - [Installation](https://github.com/sir-Unknown/ha_City-Visitor-Parking/wiki/en/Installation)
+  - [Configuration](https://github.com/sir-Unknown/ha_City-Visitor-Parking/wiki/en/Configuration)
+  - [Lovelace cards](https://github.com/sir-Unknown/ha_City-Visitor-Parking/wiki/en/Lovelace-Cards)
+  - [Services](https://github.com/sir-Unknown/ha_City-Visitor-Parking/wiki/en/Services)
+  - [Blueprints](https://github.com/sir-Unknown/ha_City-Visitor-Parking/wiki/en/Blueprints)
+  - [Troubleshooting](https://github.com/sir-Unknown/ha_City-Visitor-Parking/wiki/en/Troubleshooting)
 
   ## 🐛 Reporting issues
 
   [![Open an issue](https://img.shields.io/badge/Report%20a%20bug-red?logo=github)](https://github.com/sir-Unknown/ha_City-Visitor-Parking/issues/new)
+
+  [![Full changelog](https://img.shields.io/badge/Full%20changelog-blue?logo=github)](https://github.com/sir-Unknown/ha_City-Visitor-Parking/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION)

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -63,7 +63,7 @@ jobs:
         if: github.event.pull_request.base.ref == 'main'
         uses: release-drafter/release-drafter@139054aeaa9adc52ab36ddf67437541f039b88e2 # v7.1.1
         with:
-          disable-releaser: true
+          dry-run: true
         env:
           GITHUB_TOKEN: ${{ github.token }}
 
@@ -72,7 +72,7 @@ jobs:
         uses: release-drafter/release-drafter@139054aeaa9adc52ab36ddf67437541f039b88e2 # v7.1.1
         with:
           config-name: release-drafter-testing.yml
-          disable-releaser: true
+          dry-run: true
         env:
           GITHUB_TOKEN: ${{ github.token }}
 

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -13,6 +13,17 @@ on:
       - testing
     paths:
       - custom_components/**
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+    paths:
+      - .github/**
+      - blueprints/**
+      - tests/**
+      - "**/*.md"
+      - custom_components/**
   workflow_dispatch:
     inputs:
       prerelease:
@@ -40,8 +51,34 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  autolabel_pull_requests:
+    name: autolabel_pull_requests
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Run Release Drafter autolabeler (main)
+        if: github.event.pull_request.base.ref == 'main'
+        uses: release-drafter/release-drafter@139054aeaa9adc52ab36ddf67437541f039b88e2 # v7.1.1
+        with:
+          disable-releaser: true
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+
+      - name: Run Release Drafter autolabeler (testing)
+        if: github.event.pull_request.base.ref == 'testing'
+        uses: release-drafter/release-drafter@139054aeaa9adc52ab36ddf67437541f039b88e2 # v7.1.1
+        with:
+          config-name: release-drafter-testing.yml
+          disable-releaser: true
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+
   update_release_draft:
     name: update_release_draft
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -45,7 +45,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-      pull-requests: read # Required to read PR titles and labels for release note generation.
+      pull-requests: write # Required to read PR titles/labels and apply autolabeler labels.
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
## Summary

- Add sponsor button with inviting text, integration description (NL/EN), `[!IMPORTANT]` disclaimer, and horizontal separator to all three release templates
- Align beta and testing with stable: contributors section, full changelog badge, wiki documentation links, diagnostics instructions in bug reporting
- Add `autolabeler` (incl. `blueprints/`) and `exclude-contributors` (bots + maintainer) to stable and beta; extend testing autolabeler with `blueprints/`
- Upgrade `pull-requests` permission to `write` in the workflow so the autolabeler can actually apply labels
- Update documentation links from README to wiki; replace plain full changelog URL with a shield badge

## Test plan

- [ ] Verify rendered output of a draft release looks correct after merging
- [ ] Confirm autolabeler applies labels on a new PR after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)