### PR TITLE
ci: update release notes header with icon, badge, and TIP callout

### DIFF
--- a/.github/release-drafter-beta.yml
+++ b/.github/release-drafter-beta.yml
@@ -46,13 +46,22 @@ categories:
     labels:
       - "documentation"
 template: |
-  This integration is free and open source. If it saves you a trip to the parking portal, a beer is always appreciated! 🍺 <iframe src="https://github.com/sponsors/sir-Unknown/button" title="Sponsor sir-Unknown" height="32" width="114" style="border: 0; border-radius: 6px;"></iframe>
+  <h1><img src="https://github.com/sir-Unknown/ha_City-Visitor-Parking/blob/main/custom_components/city_visitor_parking/brand/icon@2x.png" alt="City Visitor Parking" height="80" valign="middle"> City Visitor Parking</h1>
 
-  _Beheer bezoekersparkeervergunningen van [Nederlandse gemeenten](https://github.com/sir-Unknown/ha_City-Visitor-Parking#supported-municipalities) vanuit Home Assistant. [Nederlandse documentatie](https://github.com/sir-Unknown/ha_City-Visitor-Parking/wiki/nl/Home)._
+  <br>
 
-  _Manage Dutch municipality visitor parking permits directly from Home Assistant. This integration lets you start, update, and end visitor parking sessions without having to open the municipal parking portal. Keep your favorite license plates at hand, see at a glance whether parking is paid or free, and automate your visitor parking with Home Assistant automations and scripts._
+  [![Buy me a beer](https://img.shields.io/badge/Buy%20me%20a%20beer-111111?style=for-the-badge&logo=buymeacoffee&logoColor=ffdd00)](https://github.com/sponsors/sir-Unknown)
+  _This integration is free and open source. If it saves you a trip to the parking portal, a beer is always appreciated! 🍺_
+  <br>
 
-  _The integration supports a growing number of [Dutch municipalities](https://github.com/sir-Unknown/ha_City-Visitor-Parking#supported-municipalities) and connects to their parking systems. Is your municipality not listed? You can request support or contribute — for more information: [EN](https://github.com/sir-Unknown/ha_City-Visitor-Parking/wiki/en/add-municipalities) | [NL](https://github.com/sir-Unknown/ha_City-Visitor-Parking/wiki/nl/gemeenten-toevoegen)_
+  > [!TIP]
+  > Beheer bezoekersparkeervergunningen van [Nederlandse gemeenten](https://github.com/sir-Unknown/ha_City-Visitor-Parking#supported-municipalities) vanuit Home Assistant. Voor meer informatie bekijk de [Nederlandse documentatie](https://github.com/sir-Unknown/ha_City-Visitor-Parking/wiki/nl/Home).
+  <br>
+
+  Manage Dutch municipality visitor parking permits directly from Home Assistant. This integration lets you start, update, and end visitor parking sessions without having to open the municipal parking portal. Keep your favorite license plates at hand, see at a glance whether parking is paid or free, and automate your visitor parking with Home Assistant automations and scripts.
+
+  The integration supports a growing number of [Dutch municipalities](https://github.com/sir-Unknown/ha_City-Visitor-Parking#supported-municipalities) and connects to their parking systems. Is your municipality not listed? You can request support or contribute — for more information: [EN](https://github.com/sir-Unknown/ha_City-Visitor-Parking/wiki/en/add-municipalities) | [NL](https://github.com/sir-Unknown/ha_City-Visitor-Parking/wiki/nl/gemeenten-toevoegen)
+  <br>
 
   > [!IMPORTANT]
   > This integration is under active development — thank you for using it and for your patience! Features may occasionally break, and new versions can sometimes introduce regressions. It is possible that a parking session is not correctly started, updated, or ended.

--- a/.github/release-drafter-testing.yml
+++ b/.github/release-drafter-testing.yml
@@ -46,13 +46,22 @@ categories:
     labels:
       - "documentation"
 template: |
-  This integration is free and open source. If it saves you a trip to the parking portal, a beer is always appreciated! 🍺 <iframe src="https://github.com/sponsors/sir-Unknown/button" title="Sponsor sir-Unknown" height="32" width="114" style="border: 0; border-radius: 6px;"></iframe>
+  <h1><img src="https://github.com/sir-Unknown/ha_City-Visitor-Parking/blob/main/custom_components/city_visitor_parking/brand/icon@2x.png" alt="City Visitor Parking" height="80" valign="middle"> City Visitor Parking</h1>
 
-  _Beheer bezoekersparkeervergunningen van [Nederlandse gemeenten](https://github.com/sir-Unknown/ha_City-Visitor-Parking#supported-municipalities) vanuit Home Assistant. [Nederlandse documentatie](https://github.com/sir-Unknown/ha_City-Visitor-Parking/wiki/nl/Home)._
+  <br>
 
-  _Manage Dutch municipality visitor parking permits directly from Home Assistant. This integration lets you start, update, and end visitor parking sessions without having to open the municipal parking portal. Keep your favorite license plates at hand, see at a glance whether parking is paid or free, and automate your visitor parking with Home Assistant automations and scripts._
+  [![Buy me a beer](https://img.shields.io/badge/Buy%20me%20a%20beer-111111?style=for-the-badge&logo=buymeacoffee&logoColor=ffdd00)](https://github.com/sponsors/sir-Unknown)
+  _This integration is free and open source. If it saves you a trip to the parking portal, a beer is always appreciated! 🍺_
+  <br>
 
-  _The integration supports a growing number of [Dutch municipalities](https://github.com/sir-Unknown/ha_City-Visitor-Parking#supported-municipalities) and connects to their parking systems. Is your municipality not listed? You can request support or contribute — for more information: [EN](https://github.com/sir-Unknown/ha_City-Visitor-Parking/wiki/en/add-municipalities) | [NL](https://github.com/sir-Unknown/ha_City-Visitor-Parking/wiki/nl/gemeenten-toevoegen)_
+  > [!TIP]
+  > Beheer bezoekersparkeervergunningen van [Nederlandse gemeenten](https://github.com/sir-Unknown/ha_City-Visitor-Parking#supported-municipalities) vanuit Home Assistant. Voor meer informatie bekijk de [Nederlandse documentatie](https://github.com/sir-Unknown/ha_City-Visitor-Parking/wiki/nl/Home).
+  <br>
+
+  Manage Dutch municipality visitor parking permits directly from Home Assistant. This integration lets you start, update, and end visitor parking sessions without having to open the municipal parking portal. Keep your favorite license plates at hand, see at a glance whether parking is paid or free, and automate your visitor parking with Home Assistant automations and scripts.
+
+  The integration supports a growing number of [Dutch municipalities](https://github.com/sir-Unknown/ha_City-Visitor-Parking#supported-municipalities) and connects to their parking systems. Is your municipality not listed? You can request support or contribute — for more information: [EN](https://github.com/sir-Unknown/ha_City-Visitor-Parking/wiki/en/add-municipalities) | [NL](https://github.com/sir-Unknown/ha_City-Visitor-Parking/wiki/nl/gemeenten-toevoegen)
+  <br>
 
   > [!IMPORTANT]
   > This integration is under active development — thank you for using it and for your patience! Features may occasionally break, and new versions can sometimes introduce regressions. It is possible that a parking session is not correctly started, updated, or ended.

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -67,13 +67,22 @@ version-resolver:
       - "tests"
   default: patch
 template: |
-  This integration is free and open source. If it saves you a trip to the parking portal, a beer is always appreciated! 🍺 <iframe src="https://github.com/sponsors/sir-Unknown/button" title="Sponsor sir-Unknown" height="32" width="114" style="border: 0; border-radius: 6px;"></iframe>
+  <h1><img src="https://github.com/sir-Unknown/ha_City-Visitor-Parking/blob/main/custom_components/city_visitor_parking/brand/icon@2x.png" alt="City Visitor Parking" height="80" valign="middle"> City Visitor Parking</h1>
 
-  _Beheer bezoekersparkeervergunningen van [Nederlandse gemeenten](https://github.com/sir-Unknown/ha_City-Visitor-Parking#supported-municipalities) vanuit Home Assistant. [Nederlandse documentatie](https://github.com/sir-Unknown/ha_City-Visitor-Parking/wiki/nl/Home)._
+  <br>
 
-  _Manage Dutch municipality visitor parking permits directly from Home Assistant. This integration lets you start, update, and end visitor parking sessions without having to open the municipal parking portal. Keep your favorite license plates at hand, see at a glance whether parking is paid or free, and automate your visitor parking with Home Assistant automations and scripts._
+  [![Buy me a beer](https://img.shields.io/badge/Buy%20me%20a%20beer-111111?style=for-the-badge&logo=buymeacoffee&logoColor=ffdd00)](https://github.com/sponsors/sir-Unknown)
+  _This integration is free and open source. If it saves you a trip to the parking portal, a beer is always appreciated! 🍺_
+  <br>
 
-  _The integration supports a growing number of [Dutch municipalities](https://github.com/sir-Unknown/ha_City-Visitor-Parking#supported-municipalities) and connects to their parking systems. Is your municipality not listed? You can request support or contribute — for more information: [EN](https://github.com/sir-Unknown/ha_City-Visitor-Parking/wiki/en/add-municipalities) | [NL](https://github.com/sir-Unknown/ha_City-Visitor-Parking/wiki/nl/gemeenten-toevoegen)_
+  > [!TIP]
+  > Beheer bezoekersparkeervergunningen van [Nederlandse gemeenten](https://github.com/sir-Unknown/ha_City-Visitor-Parking#supported-municipalities) vanuit Home Assistant. Voor meer informatie bekijk de [Nederlandse documentatie](https://github.com/sir-Unknown/ha_City-Visitor-Parking/wiki/nl/Home).
+  <br>
+
+  Manage Dutch municipality visitor parking permits directly from Home Assistant. This integration lets you start, update, and end visitor parking sessions without having to open the municipal parking portal. Keep your favorite license plates at hand, see at a glance whether parking is paid or free, and automate your visitor parking with Home Assistant automations and scripts.
+
+  The integration supports a growing number of [Dutch municipalities](https://github.com/sir-Unknown/ha_City-Visitor-Parking#supported-municipalities) and connects to their parking systems. Is your municipality not listed? You can request support or contribute — for more information: [EN](https://github.com/sir-Unknown/ha_City-Visitor-Parking/wiki/en/add-municipalities) | [NL](https://github.com/sir-Unknown/ha_City-Visitor-Parking/wiki/nl/gemeenten-toevoegen)
+  <br>
 
   > [!IMPORTANT]
   > This integration is under active development — thank you for using it and for your patience! Features may occasionally break, and new versions can sometimes introduce regressions. It is possible that a parking session is not correctly started, updated, or ended.


### PR DESCRIPTION
## Summary

- Replace `<iframe>` sponsor button with a shields.io "Buy me a beer" badge in all three release drafter templates
- Wrap the Dutch description in a `> [!TIP]` callout (also updated text to include "Voor meer informatie bekijk de")
- Remove italic markers from English description paragraphs
- Add branded `<h1>` header with icon image at the top of each template

## Test plan

- [ ] Verify rendered output looks correct in the next draft release on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)