### PR TITLE
fix(ci): prevent grep exit code from aborting release extraction step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -228,8 +228,8 @@ jobs:
             IS_BETA=true
           fi
 
-          COMMIT=$(echo "$RELEASE_BODY" | grep -oE '\*\*Commit:\*\* `?([a-f0-9]{40})`?' | grep -oE '[a-f0-9]{40}')
-          PYPI=$(echo "$RELEASE_BODY" | grep -oE '\*\*PyPI:\*\* `?([^` \n]+)`?' | sed 's/\*\*PyPI:\*\* //; s/`//g')
+          COMMIT=$(echo "$RELEASE_BODY" | grep -oE '\*\*Commit:\*\* `?([a-f0-9]{40})`?' | grep -oE '[a-f0-9]{40}') || true
+          PYPI=$(echo "$RELEASE_BODY" | grep -oE '\*\*PyPI:\*\* `?([^` \n]+)`?' | sed 's/\*\*PyPI:\*\* //; s/`//g') || true
 
           # Ignore placeholder values
           echo "$COMMIT" | grep -qiE '^(FILL_IN|$)' && COMMIT=""


### PR DESCRIPTION
## Summary

- The `COMMIT` and `PYPI` grep pipelines in the release workflow exit with code 1 when no match is found (e.g. when the placeholder `FILL_IN_COMMIT_SHA_OR_LEAVE_EMPTY` is used instead of a real 40-char SHA).
- Because the step runs under `bash -e`, this non-zero exit aborted the script before the validation logic or any helpful error message could run.
- Fix: append `|| true` to both extraction lines so a no-match never kills the step.

## Test plan

- [ ] Re-trigger the `v0.1.36-beta.5` release after merging to confirm the step no longer aborts when Commit is a placeholder and PyPI is filled in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)