### PR TITLE
fix(ci): detect missing requirement by pattern match, not string equality

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -292,10 +292,9 @@ jobs:
                   raise ValueError("No pycityvisitorparking requirement found to replace")
               data["requirements"] = new_reqs
           elif pycvp_pypi:
-              new_reqs = [re.sub(r'pycityvisitorparking==\S+', f'pycityvisitorparking=={pycvp_pypi}', r) for r in data["requirements"]]
-              if new_reqs == data["requirements"]:
+              if not any(re.search(r'pycityvisitorparking==\S+', r, re.IGNORECASE) for r in data["requirements"]):
                   raise ValueError("No pycityvisitorparking==... requirement found to replace")
-              data["requirements"] = new_reqs
+              data["requirements"] = [re.sub(r'pycityvisitorparking==\S+', f'pycityvisitorparking=={pycvp_pypi}', r, flags=re.IGNORECASE) for r in data["requirements"]]
           # Derive a human-readable version label for the release notes
           pycvp_req = next((r for r in data["requirements"] if re.search(r'pycityvisitorparking', r, re.IGNORECASE)), "")
           sha_match = re.search(r'[a-f0-9]{40}', pycvp_req)


### PR DESCRIPTION
## Summary

- When the PyPI version in the release body matches what is already in `manifest.json`, `re.sub` produces the same string and the equality check (`new_reqs == data["requirements"]`) falsely raises `ValueError: No pycityvisitorparking==... requirement found to replace`.
- Fix: check for the pattern's existence upfront instead of comparing before/after strings.

## Test plan

- [ ] Re-trigger the `v0.1.36-beta.5` release after merging to confirm the build completes when PyPI version in the release body matches the one already in `manifest.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)