### PR TITLE
fix: update release header image URL and cache-bust frontend translations

### DIFF
--- a/.github/release-drafter-beta.yml
+++ b/.github/release-drafter-beta.yml
@@ -46,7 +46,7 @@ categories:
     labels:
       - "documentation"
 template: |
-  <h1><img src="https://github.com/sir-Unknown/ha_City-Visitor-Parking/blob/main/custom_components/city_visitor_parking/brand/icon@2x.png" alt="City Visitor Parking" height="80" valign="middle"> City Visitor Parking</h1>
+  <h1><img src="https://raw.githubusercontent.com/sir-Unknown/ha_City-Visitor-Parking/main/custom_components/city_visitor_parking/brand/icon@2x.png" alt="City Visitor Parking" height="80" valign="middle"> City Visitor Parking</h1>
 
   <br>
 

--- a/.github/release-drafter-testing.yml
+++ b/.github/release-drafter-testing.yml
@@ -46,7 +46,7 @@ categories:
     labels:
       - "documentation"
 template: |
-  <h1><img src="https://github.com/sir-Unknown/ha_City-Visitor-Parking/blob/main/custom_components/city_visitor_parking/brand/icon@2x.png" alt="City Visitor Parking" height="80" valign="middle"> City Visitor Parking</h1>
+  <h1><img src="https://raw.githubusercontent.com/sir-Unknown/ha_City-Visitor-Parking/main/custom_components/city_visitor_parking/brand/icon@2x.png" alt="City Visitor Parking" height="80" valign="middle"> City Visitor Parking</h1>
 
   <br>
 

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -67,7 +67,7 @@ version-resolver:
       - "tests"
   default: patch
 template: |
-  <h1><img src="https://github.com/sir-Unknown/ha_City-Visitor-Parking/blob/main/custom_components/city_visitor_parking/brand/icon@2x.png" alt="City Visitor Parking" height="80" valign="middle"> City Visitor Parking</h1>
+  <h1><img src="https://raw.githubusercontent.com/sir-Unknown/ha_City-Visitor-Parking/main/custom_components/city_visitor_parking/brand/icon@2x.png" alt="City Visitor Parking" height="80" valign="middle"> City Visitor Parking</h1>
 
   <br>
 

--- a/custom_components/city_visitor_parking/frontend/dist/city-visitor-parking-card.js
+++ b/custom_components/city_visitor_parking/frontend/dist/city-visitor-parking-card.js
@@ -590,6 +590,7 @@ var i6 = e4(class extends i5 {
 // src/translations.ts
 var DEFAULT_LANGUAGE = "en";
 var BASE_URL = new URL(".", import.meta.url).toString().replace(/\/$/, "");
+var BUNDLE_VERSION = new URL(import.meta.url).searchParams.get("v") ?? "";
 var translationsCache = /* @__PURE__ */ new Map();
 var translationsInFlight = /* @__PURE__ */ new Map();
 var translationLookupCache = /* @__PURE__ */ new Map();
@@ -607,8 +608,9 @@ var getLanguage = (target) => {
   return targetLang || globalHass?.language || globalHass?.locale?.language || document.documentElement.lang || getStoredLanguage() || navigator.language || DEFAULT_LANGUAGE;
 };
 var fetchTranslations = async (baseUrl, language) => {
+  const versionSuffix = BUNDLE_VERSION ? `?v=${BUNDLE_VERSION}` : "";
   const response = await fetch(
-    `${baseUrl}/translations/${language}.json`
+    `${baseUrl}/translations/${language}.json${versionSuffix}`
   ).catch(() => null);
   if (!response || !response.ok) return null;
   try {

--- a/custom_components/city_visitor_parking/frontend/src/translations.ts
+++ b/custom_components/city_visitor_parking/frontend/src/translations.ts
@@ -3,6 +3,9 @@ import type { LocalizeFunc, LocalizeTarget, TranslationObject } from "./types";
 
 const DEFAULT_LANGUAGE = "en";
 const BASE_URL = new URL(".", import.meta.url).toString().replace(/\/$/, "");
+// Extract the cache-busting version from the bundle URL (e.g. "?v=1234") so
+// translation files loaded after an integration update are never served stale.
+const BUNDLE_VERSION = new URL(import.meta.url).searchParams.get("v") ?? "";
 const translationsCache = new Map<string, TranslationObject>();
 const translationsInFlight = new Map<string, Promise<void>>();
 const translationLookupCache = new Map<string, Map<string, string>>();
@@ -43,8 +46,9 @@ const fetchTranslations = async (
   baseUrl: string,
   language: string,
 ): Promise<TranslationObject | null> => {
+  const versionSuffix = BUNDLE_VERSION ? `?v=${BUNDLE_VERSION}` : "";
   const response = await fetch(
-    `${baseUrl}/translations/${language}.json`,
+    `${baseUrl}/translations/${language}.json${versionSuffix}`,
   ).catch(() => null);
   if (!response || !response.ok) return null;
   try {


### PR DESCRIPTION
## Summary

- switch the release notes header icon to a `raw.githubusercontent.com` URL so GitHub Releases render the image asset instead of linking to an HTML blob page
- append the frontend bundle version query parameter to translation JSON requests so updated integrations do not keep serving stale cached translations
- rebuild the distributed frontend bundle so the shipped artifact matches the source change

## Why

This branch now combines two small release-facing fixes. The CI change ensures the release notes header icon displays correctly in generated releases, while the frontend change prevents browsers from reusing outdated translation files after an integration update.

## Impact

Release notes render the intended header image consistently, and frontend users get fresh translation strings after upgrades without needing a hard refresh.

## Validation

- pre-commit hooks during `git commit`
- `frontend eslint`
- `frontend prettier`
- `frontend types`
- `frontend test`
- `frontend build`