### PR TITLE
feat: persist and reuse resolved provider login params across restarts

### DIFF
--- a/custom_components/city_visitor_parking/__init__.py
+++ b/custom_components/city_visitor_parking/__init__.py
@@ -164,6 +164,10 @@ async def async_setup_entry(
             **entry.data.get(CONF_RESOLVED_LOGIN_PARAMS, {}),
         )
     except AuthError as err:
+        if entry.data.get(CONF_RESOLVED_LOGIN_PARAMS):
+            hass.config_entries.async_update_entry(
+                entry, data={**entry.data, CONF_RESOLVED_LOGIN_PARAMS: {}}
+            )
         raise ConfigEntryAuthFailed from err
     except NetworkError as err:
         raise ConfigEntryNotReady from err
@@ -177,7 +181,7 @@ async def async_setup_entry(
             time.perf_counter() - login_started,
         )
 
-    resolved = provider.resolved_login_params
+    resolved = getattr(provider, "resolved_login_params", {})
     if resolved != entry.data.get(CONF_RESOLVED_LOGIN_PARAMS):
         hass.config_entries.async_update_entry(
             entry, data={**entry.data, CONF_RESOLVED_LOGIN_PARAMS: resolved}

--- a/custom_components/city_visitor_parking/__init__.py
+++ b/custom_components/city_visitor_parking/__init__.py
@@ -156,10 +156,9 @@ async def async_setup_entry(
         await provider.login(
             username=entry.data[CONF_USERNAME],
             password=entry.data[CONF_PASSWORD],
-            # Passes the stored permit_id as product_id (2park) to prevent
-            # _detect_product() from picking the wrong product when multiple
-            # config entries share the same provider.
-            product_id=entry.data.get(CONF_PERMIT_ID),
+            # Passes the permit_id so providers can skip auto-detection when
+            # multiple config entries share the same provider.
+            permit_id=entry.data.get(CONF_PERMIT_ID),
             # Passes previously resolved params back to skip redundant API calls
             # on restart (e.g. location for 2park, permit_media_type_id for dvsportal).
             **entry.data.get(CONF_RESOLVED_LOGIN_PARAMS, {}),

--- a/custom_components/city_visitor_parking/__init__.py
+++ b/custom_components/city_visitor_parking/__init__.py
@@ -42,6 +42,7 @@ from .const import (
     CONF_OPERATING_TIME_OVERRIDES,
     CONF_PERMIT_ID,
     CONF_PROVIDER_ID,
+    CONF_RESOLVED_LOGIN_PARAMS,
     DOMAIN,
     PLATFORMS,
     WEEKDAY_KEYS,
@@ -158,12 +159,10 @@ async def async_setup_entry(
             # Passes the stored permit_id as product_id (2park) to prevent
             # _detect_product() from picking the wrong product when multiple
             # config entries share the same provider.
-            # TODO: also persist and pass `location` (2park) so _detect_product()
-            # is skipped entirely instead of just filtered.
             product_id=entry.data.get(CONF_PERMIT_ID),
-            # TODO: pass permit_media_type_id=entry.data.get(CONF_PERMIT_ID) to
-            # avoid the extra _fetch_permit_media_type_id() API call on every
-            # restart for dvsportal/the_hague providers.
+            # Passes previously resolved params back to skip redundant API calls
+            # on restart (e.g. location for 2park, permit_media_type_id for dvsportal).
+            **entry.data.get(CONF_RESOLVED_LOGIN_PARAMS, {}),
         )
     except AuthError as err:
         raise ConfigEntryAuthFailed from err
@@ -177,6 +176,12 @@ async def async_setup_entry(
             entry.title,
             entry.data.get(CONF_PERMIT_ID),
             time.perf_counter() - login_started,
+        )
+
+    resolved = provider.resolved_login_params
+    if resolved != entry.data.get(CONF_RESOLVED_LOGIN_PARAMS):
+        hass.config_entries.async_update_entry(
+            entry, data={**entry.data, CONF_RESOLVED_LOGIN_PARAMS: resolved}
         )
 
     auto_end_state = AutoEndState()

--- a/custom_components/city_visitor_parking/const.py
+++ b/custom_components/city_visitor_parking/const.py
@@ -18,6 +18,7 @@ CONF_BASE_URL: Final = "base_url"
 CONF_API_URL: Final = "api_url"
 CONF_GUI_URL: Final = "gui_url"
 CONF_PERMIT_ID: Final = "permit_id"
+CONF_RESOLVED_LOGIN_PARAMS: Final = "resolved_login_params"
 CONF_DESCRIPTION: Final = "description"
 
 CONF_OPERATING_TIME_OVERRIDES: Final = "operating_time_overrides"

--- a/custom_components/city_visitor_parking/diagnostics.py
+++ b/custom_components/city_visitor_parking/diagnostics.py
@@ -7,7 +7,11 @@ from typing import TYPE_CHECKING, Final, Protocol, cast
 from homeassistant.components import diagnostics as diagnostics_util
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 
-from .const import CONF_AUTO_END, CONF_OPERATING_TIME_OVERRIDES
+from .const import (
+    CONF_AUTO_END,
+    CONF_OPERATING_TIME_OVERRIDES,
+    CONF_RESOLVED_LOGIN_PARAMS,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Iterable, Mapping
@@ -16,7 +20,7 @@ if TYPE_CHECKING:
 
     from .runtime_data import CityVisitorParkingConfigEntry
 
-TO_REDACT: Final[list[str]] = [CONF_PASSWORD, CONF_USERNAME]
+TO_REDACT: Final[list[str]] = [CONF_PASSWORD, CONF_USERNAME, CONF_RESOLVED_LOGIN_PARAMS]
 
 
 class _DiagnosticsModule(Protocol):

--- a/tests/components/city_visitor_parking/test_init.py
+++ b/tests/components/city_visitor_parking/test_init.py
@@ -456,6 +456,7 @@ async def _setup_entry(
     entry.mock_state(hass, config_entries.ConfigEntryState.SETUP_IN_PROGRESS)
 
     provider = AsyncMock()
+    provider.resolved_login_params = {}
     provider.fetch_all.return_value = ({"id": "permit", "zone_validity": []}, [], [])
 
     client = AsyncMock()


### PR DESCRIPTION
## Summary

- Stores provider-resolved login parameters (e.g. `permit_media_type_id` for dvsportal, `location` for 2park) in `entry.data` under `resolved_login_params` after a successful login
- Passes them back to `provider.login()` as `**kwargs` on subsequent restarts, avoiding redundant API calls
- HA never references provider-specific key names — the dict is passed generically, so **new providers require no HA changes**

Depends on: sir-Unknown/pyCityVisitorParking#feat/resolved-login-params

## Test plan

- [ ] First restart: `resolved_login_params` written to `entry.data` (verify via `.storage/core.config_entries`)
- [ ] Second restart: no extra API call (check debug logs)
- [ ] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)