### PR TITLE
[codex] use X.X.XbX beta tags

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -92,15 +92,15 @@ jobs:
             fi
           fi
           LAST=$(gh release list --limit 1000 --json tagName --jq '.[].tagName' \
-            | grep -E "^v${BASE}-beta\.[0-9]+(\+.*)?$" \
-            | grep -oE "beta\.[0-9]+" \
+            | grep -E "^v${BASE}b[0-9]+(\+.*)?$" \
+            | grep -oE "b[0-9]+" \
             | grep -oE "[0-9]+$" \
             | sort -n | tail -1)
           NEXT=$((${LAST:-0} + 1))
           if [ -n "${INPUT_SUFFIX}" ]; then
-            echo "version=${BASE}-beta.${NEXT}+${INPUT_SUFFIX}" >> "$GITHUB_OUTPUT"
+            echo "version=${BASE}b${NEXT}+${INPUT_SUFFIX}" >> "$GITHUB_OUTPUT"
           else
-            echo "version=${BASE}-beta.${NEXT}" >> "$GITHUB_OUTPUT"
+            echo "version=${BASE}b${NEXT}" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Run Release Drafter (beta pre-release)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: "Release tag to process (e.g. v1.0.0-testing.1)"
+        description: "Release tag to process (e.g. v1.0.0b1 or v1.0.0-testing.1)"
         required: true
         type: string
 
@@ -217,15 +217,26 @@ jobs:
             echo "RELEASE_BODY_EOF"
           } >> "$GITHUB_OUTPUT"
       - name: Extract pyCityVisitorParking ref from release body
-        if: contains(needs.validate.outputs.tag, '-testing.') || contains(needs.validate.outputs.tag, '-beta.')
         id: pycvp
         env:
           RELEASE_BODY: ${{ steps.release_body.outputs.body }}
           RELEASE_TAG: ${{ needs.validate.outputs.tag }}
         run: |
           IS_BETA=false
-          if echo "$RELEASE_TAG" | grep -q '\-beta\.'; then
+          IS_TESTING=false
+
+          if echo "$RELEASE_TAG" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+b[0-9]+(\+.*)?$'; then
             IS_BETA=true
+          fi
+
+          if echo "$RELEASE_TAG" | grep -q '\-testing\.'; then
+            IS_TESTING=true
+          fi
+
+          if [ "$IS_BETA" != "true" ] && [ "$IS_TESTING" != "true" ]; then
+            echo "commit=" >> "$GITHUB_OUTPUT"
+            echo "pypi=" >> "$GITHUB_OUTPUT"
+            exit 0
           fi
 
           COMMIT=$(echo "$RELEASE_BODY" | grep -oE '\*\*Commit:\*\* `?([a-f0-9]{40})`?' | grep -oE '[a-f0-9]{40}') || true

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -58,7 +58,7 @@ jobs:
   hassfest:
     name: Integration metadata (Hassfest)
     needs: [python_quality]
-    if: ${{ github.ref_name != 'testing' && !(contains(github.ref_name, '-beta') || contains(github.ref_name, '-rc') || contains(github.ref_name, '-alpha')) }}
+    if: ${{ github.ref_name != 'testing' && !(contains(github.ref_name, '-rc') || contains(github.ref_name, '-alpha') || (startsWith(github.ref, 'refs/tags/') && contains(github.ref_name, 'b'))) }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
@@ -74,7 +74,7 @@ jobs:
   hacs:
     name: Integration metadata (HACS)
     needs: [python_quality]
-    if: ${{ github.ref_name != 'testing' && !(contains(github.ref_name, '-beta') || contains(github.ref_name, '-rc') || contains(github.ref_name, '-alpha')) }}
+    if: ${{ github.ref_name != 'testing' && !(contains(github.ref_name, '-rc') || contains(github.ref_name, '-alpha') || (startsWith(github.ref, 'refs/tags/') && contains(github.ref_name, 'b'))) }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
@@ -119,7 +119,7 @@ jobs:
 
   release_policy:
     name: Release policy
-    if: ${{ github.ref_name != 'testing' && !(contains(github.ref_name, '-beta') || contains(github.ref_name, '-rc') || contains(github.ref_name, '-alpha')) }}
+    if: ${{ github.ref_name != 'testing' && !(contains(github.ref_name, '-rc') || contains(github.ref_name, '-alpha') || (startsWith(github.ref, 'refs/tags/') && contains(github.ref_name, 'b'))) }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:


### PR DESCRIPTION
## What changed
This updates the GitHub release workflows to use beta versions in `X.X.XbX` format instead of the previous `X.X.X-beta.X` format.

## Why
The repository should now treat beta prerelease versions as compact `b` suffixes consistently across draft generation, release handling, and validation gating.

## Impact
Beta release drafts are generated as tags like `v1.2.3b4`, and the release and validation workflows now recognize that format correctly.

## Root cause
The release automation still hardcoded the older `-beta.` naming pattern in several workflow conditions and tag-matching expressions.

## Validation
- `git diff --check -- .github/workflows/release-drafter.yml .github/workflows/release.yml .github/workflows/validate.yml`
- local pre-commit hooks triggered during `git commit` and passed for the affected files