### PR TITLE
ci: use semver-compatible -beta.N tag format instead of bN

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -92,15 +92,15 @@ jobs:
             fi
           fi
           LAST=$(gh release list --limit 1000 --json tagName --jq '.[].tagName' \
-            | grep -E "^v${BASE}b[0-9]+(\+.*)?$" \
-            | grep -oE "b[0-9]+" \
+            | grep -E "^v${BASE}-beta\.[0-9]+(\+.*)?$" \
+            | grep -oE "beta\.[0-9]+" \
             | grep -oE "[0-9]+$" \
             | sort -n | tail -1)
           NEXT=$((${LAST:-0} + 1))
           if [ -n "${INPUT_SUFFIX}" ]; then
-            echo "version=${BASE}b${NEXT}+${INPUT_SUFFIX}" >> "$GITHUB_OUTPUT"
+            echo "version=${BASE}-beta.${NEXT}+${INPUT_SUFFIX}" >> "$GITHUB_OUTPUT"
           else
-            echo "version=${BASE}b${NEXT}" >> "$GITHUB_OUTPUT"
+            echo "version=${BASE}-beta.${NEXT}" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Run Release Drafter (beta pre-release)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -225,7 +225,7 @@ jobs:
           IS_BETA=false
           IS_TESTING=false
 
-          if echo "$RELEASE_TAG" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+b[0-9]+(\+.*)?$'; then
+          if echo "$RELEASE_TAG" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+-beta\.[0-9]+(\+.*)?$'; then
             IS_BETA=true
           fi
 


### PR DESCRIPTION
## Summary

- `release-drafter` parses `0.1.37b1` as version `0.1.37` + prerelease label `b1`, then uses only `$RESOLVED_VERSION` (`0.1.37`) in the tag-template — resulting in an untagged draft
- Fix: switch beta version format from `0.1.37b1` to `0.1.37-beta.1` which is proper semver and correctly reflected in the generated tag `v0.1.37-beta.1`

## Test plan

- [ ] Trigger a `workflow_dispatch` beta run and verify the draft is tagged `v0.1.37-beta.1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)