### PR TITLE
ci: derive beta BASE from stable draft or next patch version

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -84,9 +84,20 @@ jobs:
           else
             MANIFEST_VERSION=$(jq -r '.version' custom_components/city_visitor_parking/manifest.json | sed 's/-.*//')
             if [ "${MANIFEST_VERSION}" = "0.0.0" ]; then
-              BASE=$(gh release list --limit 1000 --json tagName,isPrerelease,isDraft \
-                --jq '[.[] | select(.isPrerelease == false and .isDraft == false) | .tagName] | first' \
+              STABLE_DRAFT=$(gh release list --limit 1000 --json tagName,isPrerelease,isDraft \
+                --jq '[.[] | select(.isPrerelease == false and .isDraft == true) | .tagName] | first' \
                 | sed 's/^v//')
+              if [ -n "${STABLE_DRAFT}" ]; then
+                BASE="${STABLE_DRAFT}"
+              else
+                LAST_STABLE=$(gh release list --limit 1000 --json tagName,isPrerelease,isDraft \
+                  --jq '[.[] | select(.isPrerelease == false and .isDraft == false) | .tagName] | first' \
+                  | sed 's/^v//')
+                MAJOR=$(echo "${LAST_STABLE}" | cut -d. -f1)
+                MINOR=$(echo "${LAST_STABLE}" | cut -d. -f2)
+                PATCH=$(echo "${LAST_STABLE}" | cut -d. -f3)
+                BASE="${MAJOR}.${MINOR}.$((PATCH + 1))"
+              fi
             else
               BASE="${MANIFEST_VERSION}"
             fi


### PR DESCRIPTION
## Summary

- Beta dispatcher used last stable release (`v0.1.36`) as BASE, producing `v0.1.36-beta.N` even after `v0.1.36` was already published
- Fix: first check for an existing stable draft (e.g. `v0.1.37`) and use that as BASE; fall back to patching the last stable release version (`0.1.36` → `0.1.37`) when no draft exists

## Test plan

- [ ] With stable draft `v0.1.37` present: beta dispatch should produce `v0.1.37-beta.1`
- [ ] Without any stable draft: beta dispatch should produce `v0.1.37-beta.1` (patch bump from `v0.1.36`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)