### PR TITLE
fix: ensure permit_id is passed once

### DIFF
--- a/custom_components/city_visitor_parking/__init__.py
+++ b/custom_components/city_visitor_parking/__init__.py
@@ -153,15 +153,19 @@ async def async_setup_entry(
     _install_zone_validity_logging(provider)
     login_started = time.perf_counter()
     try:
+        # Passes previously resolved params back to skip redundant API calls
+        # on restart (e.g. location for 2park, permit_media_type_id for dvsportal).
+        # permit_id is popped to avoid a duplicate keyword arg since it is
+        # passed explicitly below (the provider also stores it in resolved params).
+        resolved_params = dict(entry.data.get(CONF_RESOLVED_LOGIN_PARAMS, {}))
+        resolved_params.pop(CONF_PERMIT_ID, None)
         await provider.login(
             username=entry.data[CONF_USERNAME],
             password=entry.data[CONF_PASSWORD],
             # Passes the permit_id so providers can skip auto-detection when
             # multiple config entries share the same provider.
             permit_id=entry.data.get(CONF_PERMIT_ID),
-            # Passes previously resolved params back to skip redundant API calls
-            # on restart (e.g. location for 2park, permit_media_type_id for dvsportal).
-            **entry.data.get(CONF_RESOLVED_LOGIN_PARAMS, {}),
+            **resolved_params,
         )
     except AuthError as err:
         if entry.data.get(CONF_RESOLVED_LOGIN_PARAMS):

--- a/tests/components/city_visitor_parking/test_init.py
+++ b/tests/components/city_visitor_parking/test_init.py
@@ -30,6 +30,7 @@ from custom_components.city_visitor_parking.const import (
     CONF_OPERATING_TIME_OVERRIDES,
     CONF_PERMIT_ID,
     CONF_PROVIDER_ID,
+    CONF_RESOLVED_LOGIN_PARAMS,
     DOMAIN,
 )
 
@@ -78,6 +79,41 @@ async def test_async_setup_entry_network_error(
 
     with pytest.raises(ConfigEntryNotReady):
         await init_module.async_setup_entry(hass, entry)
+
+
+async def test_async_setup_entry_resolved_params_no_duplicate_permit_id(
+    hass: HomeAssistant, monkeypatch: MonkeyPatch
+) -> None:
+    """permit_id in resolved_login_params must not cause a keyword error on restart."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            **_create_entry().data,
+            CONF_RESOLVED_LOGIN_PARAMS: {"permit_id": "permit", "location": "nl"},
+        },
+        unique_id="dvsportal:permit:city",
+        title="City - permit",
+    )
+    entry.add_to_hass(hass)
+
+    provider = AsyncMock()
+    provider.resolved_login_params = {}
+    provider.fetch_all.return_value = ({"id": "permit", "zone_validity": []}, [], [])
+    client = AsyncMock()
+    client.get_provider.return_value = provider
+
+    monkeypatch.setattr(
+        init_module, "async_create_client", AsyncMock(return_value=client)
+    )
+    monkeypatch.setattr(
+        hass.config_entries, "async_forward_entry_setups", AsyncMock(return_value=True)
+    )
+
+    await init_module.async_setup_entry(hass, entry)
+
+    kwargs = provider.login.call_args.kwargs
+    assert kwargs.get("permit_id") == "permit"
+    assert kwargs.get("location") == "nl"
 
 
 async def test_async_setup_entry_provider_error(


### PR DESCRIPTION
## Description

Encountered a bug with 2park. See logs:

```
 Error setting up entry Eindhoven - <> for city_visitor_parking

Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/config_entries.py", line 787, in __async_setup_with_context
    result = await component.async_setup_entry(hass, self)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/config/custom_components/city_visitor_parking/__init__.py", line 156, in async_setup_entry
    await provider.login(
          ~~~~~~~~~~~~~~^
        username=entry.data[CONF_USERNAME],
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ...<6 lines>...
        **entry.data.get(CONF_RESOLVED_LOGIN_PARAMS, {}),
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
TypeError: pycityvisitorparking.provider.2park.api.Provider.login() got multiple values for keyword argument 'permit_id'
```
Solution: pop() `permit_id` so that it is only passed once.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Dependencies / maintenance

## Checklist

- [ ] `ruff check` and `ruff format` pass
- [ ] `hassfest` passes
- [x] Tests added or updated
- [ ] Frontend built locally (`yarn build`) if frontend changed
- [ ] `CHANGELOG.md` updated (for user-facing changes)
